### PR TITLE
Add support for CNDP(Cloud Native Data Plane) port in BESS

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,9 +18,15 @@ jobs:
       - run: sudo sysctl -w vm.nr_hugepages=512
       - run: sudo apt-get update
       - run: sudo apt-get install -y python3-pip python3-setuptools python3-coverage python3-pyelftools ccache
-      - run: pip3 install --user -r requirements.txt
+      - run: sudo pip3 install -r requirements.txt
       - run: '[[ ${COVERAGE:-0} == 0 ]] || sudo apt-get install -y gcc-7'
       - run: '[[ ${SANITIZE:-0} == 0 ]] || sudo apt-get install -y llvm-3.9'
+      - name: Install CNDP packages
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            build-essential libbsd-dev libelf-dev libbpf-dev libjson-c-dev \
+            libnl-3-dev libnl-cli-3-dev libnuma-dev libpcap-dev meson \
+            pkg-config libgflags2.2
       - run: |
           cd env
           yes n | ./rebuild_images.py focal64
@@ -33,6 +39,7 @@ jobs:
       - run: (cd core && ./all_test --gtest_shuffle)
       - run: python3-coverage run -m unittest discover -v
       - run: python3 bessctl/run_module_tests.py
+      - run: sudo python3 bessctl/run_module_tests.py --test_dir bessctl/module_tests/cndp
       - run: ccache -s
       - run: bessctl/bessctl daemon stop
       - run: '[[ ${COVERAGE:-0} == 0 ]] || { sleep 3; codecov --gcov-exec gcov-7; }'

--- a/CNDP_README.md
+++ b/CNDP_README.md
@@ -1,0 +1,39 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2020 Intel Corporation
+-->
+
+# Cloud Native Data Plane (CNDP) BESS Port
+
+Cloud Native Data Plane (CNDP) is a collection of user space libraries for accelerating packet processing for cloud applications. It aims to provide better performance than that of standard network socket interfaces by using an I/O layer primarily built on AF_XDP, an interface that delivers packets directly to user space, bypassing the kernel networking stack. For more details refer https://cndp.io/
+
+CNDP BESS port enables sending/receiving packets to/from network interface using AF-XDP.
+
+Following are the steps required to build BESS CNDP docker image:
+
+### Step 1: Build the BESS CNDP docker image.
+
+> Note: If you are behind a proxy make sure to export/setenv http_proxy and https_proxy
+
+From the top level BESS directory call:
+
+```
+$ docker build -t besscndp --build-arg http_proxy=${http_proxy} --build-arg https_proxy=${http_proxy} -f env/Dockerfile-cndp .
+```
+
+### Step 2: Run the besscndp docker container
+
+From the top level BESS directory call:
+
+```
+$ docker run --network=host -e http_proxy=${http_proxy} -e https_proxy=${http_proxy} --privileged --cap-add=ALL -v /dev/hugepages:/mnt/huge -v /sys/bus/pci/devices:/sys/bus/pci/devices -v /sys/devices/system/node:/sys/devices/system/node -v  /lib/modules:/lib/modules -v /dev:/dev -v /usr/src:/usr/src -it besscndp bash
+```
+
+### Step 3: Run example CNDP BESS script
+
+1. Modify the jsonc file in "/build/bess/bessctl/conf/cndp/fwd.jsonc" to use the network device in your system used to send and receive n/w packets.
+2. Configure ethtool filter rules as required to send/recv packets via a specified queue id. Ensure that same netdev and queue id is configured in fwd.jsonc file.
+3. Run bessctl controller from container shell: `./bessctl/bessctl`
+4. From bessctl shell , run bess daemon: `daemon start -log_dir /build/bess/log`
+5. Run sample BESS CNDP script: `run cndp/cndpfwd_coreid`. This will run cndpfwd BESS pipeline in a core id specified in "/build/bess/bessctl/conf/cndp/cndpfwd_coreid.bess" script. Before running the script, edit the script to update core in line `bess.add_worker(wid=0, core=28)` to a core id in CPU socket where the network device is attached to get better performance.
+6. If everything works fine, then you should see BESS pipeline logs when you run: `monior pipeline`

--- a/bessctl/conf/cndp/cndpfwd.bess
+++ b/bessctl/conf/cndp/cndpfwd.bess
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2022 Intel Corporation
+
+# Example BESS script for CNDP Packet forward. It receives the ethernet packet from recvport,
+# swaps the src and dst mac address and sends the packet to sendport.
+# Port index corresponds to the ports defined in lports section in fwd.jsonc file.
+
+recvport = CndpPort(jsonc_file="/build/bess/bessctl/conf/cndp/fwd.jsonc", lport_index=0)
+sendport = CndpPort(jsonc_file="/build/bess/bessctl/conf/cndp/fwd.jsonc", lport_index=1)
+
+PortInc(port=recvport) -> MACSwap() -> PortOut(port=sendport)

--- a/bessctl/conf/cndp/cndpfwd_coreid.bess
+++ b/bessctl/conf/cndp/cndpfwd_coreid.bess
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2022 Intel Corporation
+
+# Example BESS script for CNDP Packet forward. It receives the ethernet packet from recvport, 
+# swaps the src and dst mac address and sends the packet to sendport.
+# Port index corresponds to the ports defined in lports section in fwd.jsonc file.
+# It also sets core affinity for worker thread. Before running the script,
+# edit the script to update core in line `bess.add_worker(wid=0, core=28)`
+# to a core id in CPU socket where the network device is attached to get better performance.
+
+recvport = CndpPort(jsonc_file="/build/bess/bessctl/conf/cndp/fwd.jsonc", lport_index=0)
+sendport = CndpPort(jsonc_file="/build/bess/bessctl/conf/cndp/fwd.jsonc", lport_index=1)
+
+input0 = PortInc(port=recvport)
+output0 = PortOut(port=sendport)
+
+# Swap src/dst MAC
+macswap = MACSwap()
+
+input0 -> macswap -> output0
+
+bess.add_worker(wid=0, core=28)
+input0.attach_task(wid=0)

--- a/bessctl/conf/cndp/cndpfwd_ipmac_swap.bess
+++ b/bessctl/conf/cndp/cndpfwd_ipmac_swap.bess
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2022 Intel Corporation
+
+# Example BESS script for CNDP Packet forward. It receives the Ethernet/IP packet from recvport,
+# swaps the src and dst mac and ip address and sends the packet to sendport.
+# Port index corresponds to the ports defined in lports section in fwd.jsonc file.
+
+recvport = CndpPort(jsonc_file="/build/bess/bessctl/conf/cndp/fwd.jsonc", lport_index=0)
+sendport = CndpPort(jsonc_file="/build/bess/bessctl/conf/cndp/fwd.jsonc", lport_index=1)
+
+input0 = PortInc(port=recvport)
+output0 = PortOut(port=sendport)
+
+# Swap src/dst MAC
+macswap = MACSwap()
+
+# Swap src/dst IP addresses / ports
+ipswap = IPSwap()
+
+input0 -> macswap -> ipswap -> output0

--- a/bessctl/conf/cndp/cndpfwd_queue_coreid.bess
+++ b/bessctl/conf/cndp/cndpfwd_queue_coreid.bess
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2022 Intel Corporation
+
+# Example BESS script for CNDP Packet forward. It receives the ethernet packet from recvport,
+# swaps the src and dst mac address, buffers the packet to the queue and sends the packet to sendport.
+
+recvport = CndpPort(jsonc_file="/build/bess/bessctl/conf/cndp/fwd.jsonc", lport_index=0)
+sendport = CndpPort(jsonc_file="/build/bess/bessctl/conf/cndp/fwd.jsonc", lport_index=1)
+
+input0 = PortInc(port=recvport)
+output0 = PortOut(port=sendport)
+
+queue0 = Queue()
+
+# Swap src/dst MAC
+macswap = MACSwap()
+
+input0 -> macswap -> queue0 -> output0
+
+bess.add_worker(wid=0, core=28)
+bess.add_worker(wid=1, core=29)
+input0.attach_task(wid=0)
+queue0.attach_task(wid=1)

--- a/bessctl/conf/cndp/cndpfwd_veth.bess
+++ b/bessctl/conf/cndp/cndpfwd_veth.bess
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2022 Intel Corporation
+
+# Example BESS script for CNDP Packet forward. It receives the ethernet packet from recvport,
+# swaps the src and dst mac address and sends the packet to sendport.
+# Port index corresponds to the ports defined in lports section in fwd.jsonc file.
+
+veth_port = CndpPort(jsonc_file='bessctl/conf/cndp/fwd_veth.jsonc', lport_index=0)
+
+PortInc(port=veth_port) -> MACSwap() -> PortOut(port=veth_port)

--- a/bessctl/conf/cndp/cndprecv.bess
+++ b/bessctl/conf/cndp/cndprecv.bess
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2022 Intel Corporation
+
+# Example BESS script to receive packet from CNDP port.
+# Port index corresponds to the ports defined in lports section in fwd.jsonc file.
+
+myport = CndpPort(jsonc_file="/build/bess/bessctl/conf/cndp/fwd.jsonc", lport_index=0)
+
+input0 = PortInc(port=myport)
+
+input0 -> Sink()

--- a/bessctl/conf/cndp/cndprecv_coreid.bess
+++ b/bessctl/conf/cndp/cndprecv_coreid.bess
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2022 Intel Corporation
+
+# Example BESS script to receive packet from CNDP port.
+# Port index corresponds to the ports defined in lports section in fwd.jsonc file.
+# It also sets core affinity for worker thread. Before running the script,
+# edit the script to update core in line `bess.add_worker(wid=0, core=28)`
+# to a core id in CPU socket where the network device is attached to get better performance.
+
+myport = CndpPort(jsonc_file="/build/bess/bessctl/conf/cndp/fwd.jsonc", lport_index=0)
+input0 = PortInc(port=myport)
+
+input0 -> Sink()
+
+bess.add_worker(wid=0, core=28)
+input0.attach_task(wid=0)

--- a/bessctl/conf/cndp/fwd.jsonc
+++ b/bessctl/conf/cndp/fwd.jsonc
@@ -1,0 +1,176 @@
+{
+    // SPDX-License-Identifier: BSD-3-Clause
+    // Copyright (c) 2020-2022 Intel Corporation.
+    //
+    // (R) - Required entry
+    // (O) - Optional entry
+    // All descriptions are optional and short form is 'desc'
+    // The order of the entries in this file are handled when it is parsed and the
+    // entries can be in any order.
+
+    // (R) Application information
+    //    name        - (O) the name of the application
+    //    description - (O) the description of the application
+    "application": {
+        "name": "BESS",
+        "description": "BESS CNDP Port"
+    },
+
+    // (O) Default values
+    //    bufcnt - (O) UMEM default buffer count in 1K increments
+    //    bufsz  - (O) UMEM buffer size in 1K increments
+    //    rxdesc - (O) Number of RX ring descriptors in 1K increments
+    //    txdesc - (O) Number of TX ring descriptors in 1K increments
+    //    cache  - (O) MBUF Pool cache size in number of entries
+    //    mtype  - (O) Memory type for mmap allocations
+    "defaults": {
+        "bufcnt": 16,
+        "bufsz": 2,
+        "rxdesc": 2,
+        "txdesc": 2,
+        "cache": 256,
+        "mtype": "2MB"
+    },
+
+    // List of all UMEM's to be created
+    // key/val - (R) The 'key' is the name of the umem for later reference.
+    //               The 'val' is the object describing the UMEM buffer.
+    //               Multiple umem regions can be defined.
+    // A UMEM can support multiple lports using the regions array. Each lports can use
+    // one of the regions.
+    //    bufcnt  - (R) The number of buffers in 1K increments in the UMEM space.
+    //    bufsz   - (R) The size in 1K increments of each buffer in the UMEM space.
+    //    mtype   - (O) If missing or empty string or missing means use 4KB or default system pages.
+    //    regions - (O) Array of sizes one per region in 1K increments, total must be <= bufcnt
+    //    rxdesc  - (O) Number of RX descriptors to be allocated in 1K increments,
+    //                  if not present or zero use defaults.rxdesc, normally zero.
+    //    txdesc  - (O) Number of TX descriptors to be allocated in 1K increments,
+    //                  if not present or zero use defaults.txdesc, normally zero.
+    //    description | desc - (O) Description of the umem space.
+    "umems": {
+        "umem0": {
+            "bufcnt": 32,
+            "bufsz": 2,
+            "mtype": "2MB",
+            "regions": [
+                16,
+                16
+            ],
+            "rxdesc": 0,
+            "txdesc": 0,
+            "description": "UMEM Description 0"
+        },
+        "umem1": {
+            "bufcnt": 32,
+            "bufsz": 2,
+            "mtype": "2MB",
+            "regions": [
+                16,
+                16
+            ],
+            "rxdesc": 0,
+            "txdesc": 0,
+            "description": "UMEM Description 0"
+        }
+    },
+
+
+    // List of all lports to be used in the application
+    // A lport is defined by a netdev/queue ID pair, which is a socket containing a Rx/Tx ring pair.
+    // Each queue ID is assigned to a single socket, a socket is the lport defined by netdev/qid.
+    // Note: A netdev can be shared between lports as the qid is unique per lport
+    //       If netdev is not defined or empty, then it must be a virtual interface and not
+    //       associated with a netdev/queue ID.
+    // key/val - (R) The 'key' is the logical name e.g., 'eth0:0', 'eth1:0', ... to be used by the
+    //               application to reference a lport. The 'val' object contains information about
+    //               each lport.
+    //    netdev        - (R) The netdev device to be used, the part before the colon
+    //                     must reflect the netdev name
+    //    pmd           - (R) All PMDs have a name i.e., 'net_af_xdp', 'ring', ...
+    //    qid           - (R) Is the queue id to use for this lport, defined by ethtool command line
+    //    umem          - (R) The UMEM assigned to this lport
+    //    region        - (O) UMEM region index value, default region 0
+    //    busy_poll     - (O) Enable busy polling support, true or false, default false
+    //    busy_timeout  - (O) 1-65535 or 0 - use default value, values in milliseconds
+    //    busy_budget   - (O) 0xFFFF disabled, 0 use default, >0 budget value
+    //    inhibit_prog_load - (O) Inhibit loading the BPF program if true, default false
+    //    force_wakeup  - (O) Force TX wakeup calls for CVL NIC, default false
+    //    skb_mode      - (O) Enable XDP_FLAGS_SKB_MODE when creating af_xdp socket, forces copy mode, default false
+    //    description   - (O) The description, 'desc' can be used as well
+    "lports": {
+        "enp134s0:0": {
+            "pmd": "net_af_xdp",
+            "qid": 23,
+            "umem": "umem0",
+            "region": 0,
+            "description": "LAN 0 port"
+        },
+        "enp134s0:1": {
+            "pmd": "net_af_xdp",
+            "qid": 33,
+            "umem": "umem0",
+            "region": 1,
+            "description": "LAN 1 port"
+        }
+    },
+
+    // (O) Define the lcore groups for each thread to run
+    //     Can be integers or a string for a range of lcores
+    //     e.g., [10], [10-14,16], [10-12, 14-15, 17-18, 20]
+    // Names of a lcore group and its lcores assigned to the group.
+    // The initial group is for the main thread of the application.
+    // The default group is special and is used if a thread if not assigned to a group.
+    //
+    // CNDP BESS Port does not use this section.
+    "lcore-groups": {
+        "initial": [22],
+        "group0": [25],
+        "group1": [35],
+        "default": ["22-35"]
+    },
+
+    // (O) Set of common options application defined.
+    //     The Key can be any string and value can be boolean, string, array or integer
+    //     An array must contain only a single value type, boolean, integer, string and
+    //     can't be a nested array.
+    //   pkt_api    - (O) Set the type of packet API xskdev or pktdev
+    //   no-metrics - (O) Disable metrics gathering and thread
+    //   no-restapi - (O) Disable RestAPI support
+    //   cli        - (O) Enable/Disable CLI supported
+    //   mode       - (O) Mode type [drop | rx-only], tx-only, [lb | loopback], fwd, acl-strict, acl-permissive
+    "options": {
+        "pkt_api": "xskdev",
+        "no-metrics": false,
+        "no-restapi": false,
+        "cli": true,
+        "mode": "drop"
+    },
+
+    // List of threads to start and information for the thread(s). Application can start
+    // its own threads for any reason and are not required to be configured by this file.
+    //
+    //   Key/Val   - (R) A unique thread name.
+    //                   The format is <type-string>[:<identifier>] the ':' and identifier
+    //                   are optional if all thread names are unique
+    //      group  - (O) The lcore-group this thread belongs to. The
+    //      lports - (O) The list of lports assigned to this thread and cannot share lports.
+    //      description | desc - (O) The description
+    //
+    // CNDP BESS Port does not use this section.
+    "threads": {
+        "main": {
+            "group": "initial",
+            "description": "CLI Thread"
+        },
+        "fwd:0": {
+            "group": "group0",
+            "lports": ["enp134s0:0"],
+            "description": "Thread 0"
+        },
+        "fwd:1": {
+            "group": "group1",
+            "lports": ["enp134s0:1"],
+            "description": "Thread 1"
+        }
+    }
+}

--- a/bessctl/conf/cndp/fwd_veth.jsonc
+++ b/bessctl/conf/cndp/fwd_veth.jsonc
@@ -1,0 +1,151 @@
+{
+    // SPDX-License-Identifier: BSD-3-Clause
+    // Copyright (c) 2020-2022 Intel Corporation.
+    //
+    // (R) - Required entry
+    // (O) - Optional entry
+    // All descriptions are optional and short form is 'desc'
+    // The order of the entries in this file are handled when it is parsed and the
+    // entries can be in any order.
+
+    // (R) Application information
+    //    name        - (O) the name of the application
+    //    description - (O) the description of the application
+    "application": {
+        "name": "BESS",
+        "description": "BESS CNDP Port"
+    },
+
+    // (O) Default values
+    //    bufcnt - (O) UMEM default buffer count in 1K increments
+    //    bufsz  - (O) UMEM buffer size in 1K increments
+    //    rxdesc - (O) Number of RX ring descriptors in 1K increments
+    //    txdesc - (O) Number of TX ring descriptors in 1K increments
+    //    cache  - (O) MBUF Pool cache size in number of entries
+    //    mtype  - (O) Memory type for mmap allocations
+    "defaults": {
+        "bufcnt": 1,
+        "bufsz": 1,
+        "rxdesc": 1,
+        "txdesc": 1,
+        "cache": 256,
+        "mtype": "4KB"
+    },
+
+    // List of all UMEM's to be created
+    // key/val - (R) The 'key' is the name of the umem for later reference.
+    //               The 'val' is the object describing the UMEM buffer.
+    //               Multiple umem regions can be defined.
+    // A UMEM can support multiple lports using the regions array. Each lports can use
+    // one of the regions.
+    //    bufcnt  - (R) The number of buffers in 1K increments in the UMEM space.
+    //    bufsz   - (R) The size in 1K increments of each buffer in the UMEM space.
+    //    mtype   - (O) If missing or empty string or missing means use 4KB or default system pages.
+    //    regions - (O) Array of sizes one per region in 1K increments, total must be <= bufcnt
+    //    rxdesc  - (O) Number of RX descriptors to be allocated in 1K increments,
+    //                  if not present or zero use defaults.rxdesc, normally zero.
+    //    txdesc  - (O) Number of TX descriptors to be allocated in 1K increments,
+    //                  if not present or zero use defaults.txdesc, normally zero.
+    //    description | desc - (O) Description of the umem space.
+    "umems": {
+        "umem0": {
+            "bufcnt": 1,
+            "bufsz": 1,
+            "mtype": "4KB",
+            "regions": [
+                1
+            ],
+            "rxdesc": 0,
+            "txdesc": 0,
+            "description": "UMEM Description 0"
+        }
+    },
+
+
+    // List of all lports to be used in the application
+    // A lport is defined by a netdev/queue ID pair, which is a socket containing a Rx/Tx ring pair.
+    // Each queue ID is assigned to a single socket, a socket is the lport defined by netdev/qid.
+    // Note: A netdev can be shared between lports as the qid is unique per lport
+    //       If netdev is not defined or empty, then it must be a virtual interface and not
+    //       associated with a netdev/queue ID.
+    // key/val - (R) The 'key' is the logical name e.g., 'eth0:0', 'eth1:0', ... to be used by the
+    //               application to reference a lport. The 'val' object contains information about
+    //               each lport.
+    //    netdev        - (R) The netdev device to be used, the part before the colon
+    //                     must reflect the netdev name
+    //    pmd           - (R) All PMDs have a name i.e., 'net_af_xdp', 'ring', ...
+    //    qid           - (R) Is the queue id to use for this lport, defined by ethtool command line
+    //    umem          - (R) The UMEM assigned to this lport
+    //    region        - (O) UMEM region index value, default region 0
+    //    busy_poll     - (O) Enable busy polling support, true or false, default false
+    //    busy_timeout  - (O) 1-65535 or 0 - use default value, values in milliseconds
+    //    busy_budget   - (O) 0xFFFF disabled, 0 use default, >0 budget value
+    //    inhibit_prog_load - (O) Inhibit loading the BPF program if true, default false
+    //    force_wakeup  - (O) Force TX wakeup calls for CVL NIC, default false
+    //    skb_mode      - (O) Enable XDP_FLAGS_SKB_MODE when creating af_xdp socket, forces copy mode, default false
+    //    description   - (O) The description, 'desc' can be used as well
+    "lports": {
+        "veth1:0": {
+            "pmd": "net_af_xdp",
+            "qid": 0,
+            "umem": "umem0",
+            "region": 0,
+	    "skb_mode": true,
+            "description": "LAN 0 port"
+        }
+    },
+
+    // (O) Define the lcore groups for each thread to run
+    //     Can be integers or a string for a range of lcores
+    //     e.g., [10], [10-14,16], [10-12, 14-15, 17-18, 20]
+    // Names of a lcore group and its lcores assigned to the group.
+    // The initial group is for the main thread of the application.
+    // The default group is special and is used if a thread if not assigned to a group.
+    //
+    // CNDP BESS Port does not use this section.
+    "lcore-groups": {
+        "initial": [0],
+        "group0": [1],
+        "default": ["0-1"]
+    },
+
+    // (O) Set of common options application defined.
+    //     The Key can be any string and value can be boolean, string, array or integer
+    //     An array must contain only a single value type, boolean, integer, string and
+    //     can't be a nested array.
+    //   pkt_api    - (O) Set the type of packet API xskdev or pktdev
+    //   no-metrics - (O) Disable metrics gathering and thread
+    //   no-restapi - (O) Disable RestAPI support
+    //   cli        - (O) Enable/Disable CLI supported
+    //   mode       - (O) Mode type [drop | rx-only], tx-only, [lb | loopback], fwd, acl-strict, acl-permissive
+    "options": {
+        "pkt_api": "xskdev",
+        "no-metrics": false,
+        "no-restapi": false,
+        "cli": true,
+        "mode": "drop"
+    },
+
+    // List of threads to start and information for the thread(s). Application can start
+    // its own threads for any reason and are not required to be configured by this file.
+    //
+    //   Key/Val   - (R) A unique thread name.
+    //                   The format is <type-string>[:<identifier>] the ':' and identifier
+    //                   are optional if all thread names are unique
+    //      group  - (O) The lcore-group this thread belongs to. The
+    //      lports - (O) The list of lports assigned to this thread and cannot share lports.
+    //      description | desc - (O) The description
+    //
+    // CNDP BESS Port does not use this section.
+    "threads": {
+        "main": {
+            "group": "initial",
+            "description": "CLI Thread"
+        },
+        "fwd:0": {
+            "group": "group0",
+            "lports": ["veth1:0"],
+            "description": "Thread 0"
+        }
+    }
+}

--- a/bessctl/module_tests/buffer.py
+++ b/bessctl/module_tests/buffer.py
@@ -33,7 +33,7 @@ from test_utils import *
 
 # BESS default batch size
 # TODO: Any way to receive the parameter from bess daemon?
-BATCH_SIZE = 32
+BATCH_SIZE = 64
 
 
 class BessBufferTest(BessModuleTestCase):

--- a/bessctl/module_tests/cndp/cndp_veth.py
+++ b/bessctl/module_tests/cndp/cndp_veth.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2020-2022 Intel Corporation.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from test_utils import *
+from pyroute2 import IPRoute
+import scapy.all as scapy
+
+
+def create_veth():
+    ipr = IPRoute()
+    check_veth_dev1 = ipr.link_lookup(ifname='veth1')
+    if len(check_veth_dev1) == 0 :
+        ipr.link('add', ifname='veth1', kind='veth', peer='veth2')
+
+    # lookup the index
+    veth_dev1 = ipr.link_lookup(ifname='veth1')[0]
+    veth_dev2 = ipr.link_lookup(ifname='veth2')[0]
+
+    # bring it down
+    ipr.link('set', index=veth_dev1, state='down')
+    ipr.link('set', index=veth_dev2, state='down')
+
+    # add primary IP address
+    ipr.addr('add', index=veth_dev1,
+             address='10.0.0.2', mask=24,
+             broadcast='10.0.0.255')
+             
+    ipr.addr('add', index=veth_dev2,
+             address='10.0.0.3', mask=24,
+             broadcast='10.0.0.255')         
+             
+    # bring it up
+    ipr.link('set', index=veth_dev1, state='up')
+    ipr.link('set', index=veth_dev2, state='up')
+
+def gen_packet():
+    eth = scapy.Ether()
+    ip = scapy.IP(src='10.0.0.2', dst='10.0.0.3')
+    udp = scapy.UDP(sport=10001, dport=10002)
+    payload = 'helloworld'
+    pkt = eth/ip/udp/payload
+    return pkt
+
+def delete_veth():
+    ipr = IPRoute()
+    check_veth_dev1 = ipr.link_lookup(ifname='veth1')
+    if len(check_veth_dev1) > 0 :
+        ipr.link('delete', ifname='veth1')
+
+
+class BessCndpTest(BessModuleTestCase):    
+
+    def test_cndp_veth(self):
+        try:
+            # Create veth pair [veth1, veth2]. 
+            # CNDP port will use veth2 as configured in cndpfwd_veth.bess and conf/cndp/fwd_veth.jsonc.
+            create_veth()      
+            # Create CNDP BESS port.
+            veth_port = CndpPort(jsonc_file='bessctl/conf/cndp/fwd_veth.jsonc', lport_index=0)
+            PortInc(port=veth_port) -> MACSwap() -> PortOut(port=veth_port)
+        except:
+            delete_veth()
+            assert False          
+
+        # Send packets to veth2. This will be received by veth1.
+        scapy.sendp(gen_packet(),iface="veth2", count=10)
+
+        # Delete veth pair.
+        delete_veth()
+    
+
+suite = unittest.TestLoader().loadTestsFromTestCase(BessCndpTest)
+results = unittest.TextTestRunner(verbosity=2).run(suite)
+
+if results.failures or results.errors:
+    sys.exit(1)

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,5 +1,6 @@
 # Copyright (c) 2014-2017, The Regents of the University of California.
 # Copyright (c) 2016-2017, Nefeli Networks, Inc.
+# Copyright (c) 2020-2022 Intel Corporation.
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -29,6 +30,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+
 
 # Disable all implicit Makefile rules
 MAKEFLAGS += --no-builtin-rules
@@ -69,7 +71,7 @@ ALWAYS_DYN_LIBS := -lpthread -ldl
 # These libraries are not supported by pkg-config.
 ALWAYS_LIBS := -lpcap -lgflags -lnuma
 # If pkg-config is available, we just need a list of the dependecies.
-PKG_CONFIG_DEPS := libdpdk libglog protobuf grpc++ libunwind zlib
+PKG_CONFIG_DEPS := libdpdk libglog protobuf grpc++ libunwind zlib libcndp
 # If pkg-config is not available, we need to list the libs we depend on.
 NO_PKG_CONFIG_LIBS := -lglog -lgflags -lprotobuf -lgrpc++ -lunwind -lz
 # If pkg-config is not available and we're static linking, we also need

--- a/core/drivers/cndp.cc
+++ b/core/drivers/cndp.cc
@@ -1,0 +1,1059 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2019-2021 Intel Corporation.
+ */
+
+#include "cndp.h"
+#include <algorithm>        // std::min
+#include <bsd/string.h>     // for strlcpy
+#include <cne_common.h>     // for MEMPOOL_CACHE_MAX_SIZE, __cne_unused
+#include <cne_lport.h>      // for lport_cfg
+#include <cne_mmap.h>       // for mmap_addr, mmap_alloc, mmap_size, mmap_t
+#include <cne_system.h>     // for cne_device_socket_id
+#include <filesystem>       // std::filesystem::exists
+#include <fstream>          // std::ifstream
+#include <getopt.h>         // for getopt_long, option
+#include <glog/logging.h>   // for logging
+#include <jcfg.h>           // for jcfg_obj_t, jcfg_umem_t, jcfg_opt_t
+#include <jcfg_process.h>   // for jcfg_process
+#include <metrics.h>        // for cndp metrics
+#include <netdev_funcs.h>   // netdev_get_mac_addr
+#include <netinet/ether.h>  // mac_addr
+#include <pktdev.h>         // for pktdev_rx_burst, pktdev_tx_burst
+#include <pktdev_api.h>  // for pktdev_buf_alloc, pktdev_close, pktdev_port_setup
+#include <pktmbuf.h>     // for pktmbuf_pool_create, pktmbuf_info_t
+#include <pmd_af_xdp.h>  // for PMD_NET_AF_XDP_NAME
+#include <rte_mbuf.h>    // rte_mbuf
+#include <stdio.h>       // for NULL, printf, EOF
+#include <stdlib.h>      // for free, calloc
+#include <string.h>      // for strcmp
+#include <strings.h>     // for strcasecmp
+#include <thread>        // std::thread::id
+#include <unistd.h>      // usleep
+
+CommandResponse CndpPort::Init(const bess::pb::CndpPortArg &arg) {
+  jsonc_file_ = arg.jsonc_file();
+  LOG(INFO) << "CNDP parse jsonc file = " << jsonc_file_;
+  if (!std::filesystem::exists(jsonc_file_)) {
+    LOG(ERROR) << "jsonc file doesn't exist";
+    return CommandFailure(EINVAL, "jsonc file doesn't exist");
+  }
+
+  // Register this thread with CNDP if required.
+  if (CndpSingleton::CndpRegisterThread("Init") < 0) {
+    const char *err_msg = "Register thread with CNDP failed";
+    LOG(ERROR) << err_msg;
+    return CommandFailure(EINVAL, "%s", err_msg);
+  }
+
+  // Get/Create CNDP instance.
+  cndp_instance_ = &CndpSingleton::GetInstance(jsonc_file_);
+  if (!cndp_instance_->IsConfigured()) {
+    std::string err = "CNDP configuration failed for jsonc file: " +
+                      std::filesystem::canonical(jsonc_file_).string();
+    const char *err_msg = err.c_str();
+    LOG(ERROR) << err_msg;
+    return CommandFailure(EINVAL, "%s", err_msg);
+  }
+
+  // Check if lports are present.
+  int num_lports = cndp_instance_->GetNumLports();
+  if (num_lports <= 0) {
+    const char *err_msg = "No lports found in jsonc file";
+    LOG(ERROR) << err_msg;
+    return CommandFailure(EINVAL, "%s", err_msg);
+  }
+
+  // Validate lport index.
+  lport_index_ = arg.lport_index();
+  if (lport_index_ >= (uint32_t)num_lports) {
+    const char *err_msg = "Invalid lport index";
+    LOG(ERROR) << err_msg << " lport index = " << lport_index_;
+    LOG(WARNING) << "lport index should be >=0 and <" << num_lports;
+    return CommandFailure(EINVAL, "%s", err_msg);
+  }
+  LOG(INFO) << "CNDP lport index = " << lport_index_;
+
+  // Get lport instance.
+  lport_ = cndp_instance_->GetLportFromIndex(lport_index_);
+  if (lport_ == nullptr) {
+    const char *err_msg = "CNDP jcfg lport is null";
+    LOG(ERROR) << err_msg;
+    return CommandFailure(EINVAL, "%s", err_msg);
+  }
+
+  // Get fwd port from lport.
+  lport_fport_ = cndp_instance_->GetFwdPort(lport_);
+  if (lport_fport_ == nullptr) {
+    const char *err_msg = "CNDP fwd port is null";
+    LOG(ERROR) << err_msg;
+    return CommandFailure(EINVAL, "%s", err_msg);
+  }
+
+  if (lport_fport_->pkt_api == PKTDEV_PKT_API) {
+    // Reset pkt_recv_vector_
+    pkt_recv_vector_.fill(nullptr);
+  }
+
+  // Reset stats.
+  CndpStats(true);
+
+  // Get mac address for this lport.
+  struct ether_addr mac_addr;
+  if (lport_fport_->pkt_api == XSKDEV_PKT_API) {
+    netdev_get_mac_addr(lport_fport_->xsk->ifname, &mac_addr);
+  } else {
+    pktdev_macaddr_get(lport_fport_->lport, &mac_addr);
+  }
+
+  // Fill mac address of netdev in Bess port conf_.
+  memcpy(conf_.mac_addr.bytes, mac_addr.ether_addr_octet,
+         sizeof(mac_addr.ether_addr_octet));
+
+  // Get CPU socket id.
+  if (lport_fport_->pkt_api == XSKDEV_PKT_API) {
+    lport_socket_id_ = CndpSingleton::GetSocketId(lport_fport_->xsk->ifname);
+  } else {
+    // Get CPU socket id for this lport.
+    lport_socket_id_ = cndp_instance_->GetSocketId(lport_fport_->lport);
+  }
+  if (lport_socket_id_ < 0) {
+    LOG(WARNING) << "Unable to get a valid CPU socket id. Using 0 by default";
+    lport_socket_id_ = 0;
+  }
+
+  return CommandSuccess();
+}
+
+void CndpPort::DeInit() {
+  LOG(INFO) << "Called CndpPort::DeInit()";
+
+  if (cndp_instance_ != nullptr) {
+    cndp_instance_->Quit();
+    cndp_instance_ = nullptr;
+  }
+}
+
+placement_constraint CndpPort::GetNodePlacementConstraint() const {
+  return (placement_constraint)(1ull << lport_socket_id_);
+}
+
+bool CndpPort::ReplenishRecvVector(int cnt) {
+  DCHECK_LE(cnt, bess::PacketBatch::kMaxBurst);
+  bool allocated =
+      current_worker.packet_pool()->AllocBulk(pkt_recv_vector_.data(), cnt);
+  if (!allocated) {
+    LOG(ERROR) << "packet_pool() allocation failed";
+  }
+  return allocated;
+}
+
+void CndpPort::FreeRecvVector() {
+  for (auto *pkt : pkt_recv_vector_) {
+    bess::Packet::Free(pkt);
+  }
+}
+
+int CndpPort::RecvPackets(queue_t qid __cne_unused, bess::Packet **pkts,
+                          int cnt) {
+  // Register this thread with CNDP if required.
+  if (CndpSingleton::CndpRegisterThread("CndpRecvPackets") < 0) {
+    LOG(ERROR) << "Register thread with CNDP failed";
+    return 0;
+  }
+
+  // Read cnt packets from lport.
+  fwd_port *fport = lport_fport_;
+  if (fport == nullptr) {
+    LOG(ERROR) << "fwd port is NULL. Can't read packets from lport";
+    return 0;
+  }
+
+  if (cnt <= 0 || pkts == nullptr) {
+    return 0;
+  }
+
+  uint16_t num_pkts_read = 0;
+  if (fport->pkt_api == XSKDEV_PKT_API) {
+    num_pkts_read = XskdevRecvPackets(fport, pkts, cnt);
+  } else {
+    num_pkts_read = PktdevRecvPackets(fport, pkts, cnt);
+  }
+
+  return num_pkts_read;
+}
+
+int CndpPort::SendPackets(queue_t qid __cne_unused, bess::Packet **pkts,
+                          int cnt) {
+  // Register this thread with CNDP if required.
+  if (CndpSingleton::CndpRegisterThread("CndpSendPackets") < 0) {
+    LOG(ERROR) << "Register thread with CNDP failed";
+    return 0;
+  }
+
+  fwd_port *fport = lport_fport_;
+  if (fport == nullptr) {
+    LOG(ERROR) << "fwd port is NULL. Can't send packets from lport";
+    return 0;
+  }
+
+  if (cnt <= 0 || pkts == nullptr) {
+    return 0;
+  }
+
+  // Send pkts.
+  int sent = 0;
+  if (fport->pkt_api == XSKDEV_PKT_API) {
+    sent = XskdevSendPackets(fport, pkts, cnt);
+  } else {
+    sent = PktdevSendPackets(fport, pkts, cnt);
+  }
+
+  return sent;
+}
+
+uint16_t CndpPort::XskdevRecvPackets(struct fwd_port *fport,
+                                     bess::Packet **pkts, int cnt) {
+  return xskdev_rx_burst(fport->xsk, (void **)pkts, cnt);
+}
+
+uint16_t CndpPort::PktdevRecvPackets(struct fwd_port *fport,
+                                     bess::Packet **pkts, int cnt) {
+  pktmbuf_t **mbufs = &fport->mbufs[0];
+  uint16_t num_pkts_read = pktdev_rx_burst(fport->lport, mbufs, cnt);
+
+  if (num_pkts_read == 0) {
+    // No packets read.
+    return 0;
+  }
+
+  bool ret = ReplenishRecvVector(num_pkts_read);
+  if (!ret) {
+    pktmbuf_free_bulk(mbufs, num_pkts_read);
+    LOG(ERROR) << "Allocation of vector failed";
+    return 0;
+  }
+
+  for (uint16_t i = 0; i < num_pkts_read; i++) {
+    pktmbuf_t *pkt_mbuf = fport->mbufs[i];
+    if ((pkt_mbuf == nullptr) || (pkt_mbuf->data_len == 0)) {
+      pktmbuf_free_bulk(mbufs, num_pkts_read);
+      FreeRecvVector();
+      LOG(ERROR) << "pkt_mbuf is either NULL of of zero length";
+      return 0;
+    }
+
+    bess::Packet *pkt = pkt_recv_vector_[i];
+    void *pktmbuf_data = pktmbuf_mtod(pkt_mbuf, void *);
+    int copy_len = std::min(pkt_mbuf->data_len, pkt->tailroom());
+    bess::utils::CopyInlined(pkt->append(copy_len), pktmbuf_data, copy_len,
+                             true);
+    pkts[i] = pkt;
+  }
+  // Free mbufs.
+  pktmbuf_free_bulk(mbufs, num_pkts_read);
+
+  return num_pkts_read;
+}
+
+uint16_t CndpPort::XskdevSendPackets(struct fwd_port *fport,
+                                     bess::Packet **pkts, int cnt) {
+  struct rte_mbuf *mbuf = (struct rte_mbuf *)(pkts[0]);
+  bool same_pool = (mbuf->pool->pool_id == fport->bess_pool->pool()->pool_id);
+  if (same_pool) {
+    // Packets belong to same memory pool.
+    return xskdev_tx_burst(fport->xsk, (void **)pkts, cnt);
+  } else {
+    LOG_FIRST_N(INFO, 1) << "Packets belong to different mempools";
+    bess::Packet *alloc_pkts[CNDP_MAX_BURST];
+    uint16_t n_pkts = fport->xsk->buf_mgmt.buf_alloc(
+        fport, (void **)alloc_pkts,
+        ((cnt < CNDP_MAX_BURST) ? cnt : CNDP_MAX_BURST));
+
+    if (n_pkts == 0) {
+      LOG_FIRST_N(WARNING, 10) << "Cannot allocate any buffers to send packets";
+      return 0;
+    }
+
+    if (n_pkts < cnt) {
+      LOG_FIRST_N(WARNING, 10)
+          << "Cannot allocate enough buffers to send all packets"
+          << " Requested=" << cnt << ", Allocated=" << n_pkts;
+    }
+    // Copy packets across mempools.
+    for (uint16_t i = 0; i < n_pkts; i++) {
+      bess::utils::CopyInlined(alloc_pkts[i]->append(pkts[i]->total_len()),
+                               pkts[i]->head_data(), pkts[i]->total_len(),
+                               true);
+    }
+
+    uint16_t sent = xskdev_tx_burst(fport->xsk, (void **)alloc_pkts, n_pkts);
+    if (sent < n_pkts) {
+      LOG_FIRST_N(WARNING, 10) << "Free packets which are not sent"
+                               << " Requested=" << n_pkts << ", Sent=" << sent;
+      // Free allocated packets which are not sent.
+      fport->xsk->buf_mgmt.buf_free(fport, (void **)(alloc_pkts + sent),
+                                    n_pkts - sent);
+    }
+    // Free BESS packets which are sent.
+    bess::Packet::Free(pkts, sent);
+    return sent;
+  }
+
+  return 0;
+}
+
+uint16_t CndpPort::PktdevSendPackets(struct fwd_port *fport,
+                                     bess::Packet **pkts, int cnt) {
+  pktmbuf_t **mbufs = &fport->mbufs[0];
+  uint16_t n_pkts = pktdev_buf_alloc(fport->lport, mbufs, cnt);
+
+  if (n_pkts == 0) {
+    LOG_FIRST_N(WARNING, 10) << "Cannot allocate any buffers to send packets";
+    return 0;
+  }
+
+  if (n_pkts < cnt) {
+    LOG_FIRST_N(WARNING, 10)
+        << "Cannot allocate enough buffers to send all packets"
+        << " Requested=" << cnt << ", Allocated=" << n_pkts;
+  }
+
+  for (uint16_t i = 0; i < n_pkts; i++) {
+    pktmbuf_t *pkt_mbuf = fport->mbufs[i];
+    bess::Packet *pkt = pkts[i];
+    void *pktmbuf_data = pktmbuf_mtod(pkt_mbuf, void *);
+    bess::utils::CopyInlined(pktmbuf_data, pkt->head_data<const u_char *>(),
+                             pkt->data_len(), true);
+    pkt_mbuf->data_len = pkt->data_len();
+  }
+
+  // Send pkts.
+  uint16_t sent = pktdev_tx_burst(fport->lport, mbufs, n_pkts);
+  if (sent < n_pkts) {
+    LOG_FIRST_N(WARNING, 10) << "Free packets which are not sent"
+                             << " Requested=" << n_pkts << ", Sent=" << sent;
+    // Free allocated CNDP pktmbufs which are not sent.
+    pktmbuf_free_bulk(mbufs + sent, n_pkts - sent);
+  }
+
+  // Free packets which are sent.
+  bess::Packet::Free(pkts, sent);
+
+  return sent;
+}
+
+void CndpPort::CndpStats(bool reset) {
+  fwd_port *fport = lport_fport_;
+  if (fport) {
+    if (reset) {
+      LOG(INFO) << "Reset cndp stats";
+      memset(&cndp_stats_, 0, sizeof(cndp_stats_));
+      if (fport->pkt_api == XSKDEV_PKT_API) {
+        xskdev_stats_reset(fport->xsk);
+      } else {
+        pktdev_stats_reset(fport->lport);
+      }
+
+      return;
+    }
+    if (fport->pkt_api == XSKDEV_PKT_API) {
+      xskdev_stats_get(fport->xsk, &cndp_stats_);
+    } else {
+      pktdev_stats_get(fport->lport, &cndp_stats_);
+    }
+  }
+
+  // Log first two packets.
+  LOG_FIRST_N(INFO, 2) << "CndpStats:packets = " << cndp_stats_.ipackets;
+  LOG_FIRST_N(INFO, 2) << "CndpStats:bytes = " << cndp_stats_.ibytes;
+  LOG_FIRST_N(INFO, 2) << "CndpStats:dropped = " << cndp_stats_.imissed;
+}
+
+void CndpPort::CollectStats(bool reset) {
+  if (reset) {
+    CndpStats(true);
+    return;
+  }
+  // Get CNDP port stats.
+  CndpStats(false);
+
+  // Update BESS CNDP port stats.
+  port_stats_.inc.packets = cndp_stats_.ipackets;
+  port_stats_.inc.bytes = cndp_stats_.ibytes;
+  port_stats_.inc.dropped = cndp_stats_.imissed;
+  port_stats_.out.packets = cndp_stats_.opackets;
+  port_stats_.out.bytes = cndp_stats_.obytes;
+  port_stats_.out.dropped = cndp_stats_.odropped;
+
+  // There is no BESS queue stats for CNDP lport.
+  packet_dir_t dir;
+  queue_t qid;
+  dir = PACKET_DIR_INC;
+  for (qid = 0; qid < num_queues[dir]; qid++) {
+    queue_stats[dir][qid].packets = 0;
+    queue_stats[dir][qid].bytes = 0;
+    queue_stats[dir][qid].dropped = 0;
+  }
+
+  dir = PACKET_DIR_OUT;
+  for (qid = 0; qid < num_queues[dir]; qid++) {
+    queue_stats[dir][qid].packets = 0;
+    queue_stats[dir][qid].bytes = 0;
+    queue_stats[dir][qid].dropped = 0;
+  }
+}
+
+// CNDP memory pool.
+CndpPacketPoolMap CndpSingleton::cndp_packet_pool_;
+
+// CndpSingleton public member functions.
+CndpSingleton &CndpSingleton::GetInstance(const std::string &jsonc_file) {
+  // Cndp instance will be lazy initialized.
+  static CndpSingleton instance(jsonc_file);
+  // Reconfigure CNDP if JSONC file has changed.
+  if (instance.jsonc_file_ != jsonc_file) {
+    LOG(INFO) << "Jsonc file changed. Reconfigure CNDP";
+    memset(&(instance.fwd_), 0, sizeof(instance.fwd_));
+    if (instance.ParseFile(jsonc_file.c_str(), &instance.fwd_) < 0) {
+      LOG(ERROR) << "CNDP parse jsonc failed";
+      instance.configured_ = false;
+      return instance;
+    }
+    instance.configured_ = true;
+    instance.jsonc_file_ = jsonc_file;
+  }
+  return instance;
+}
+
+void CndpSingleton::Quit() {
+  // If CNDP is not configured return.
+  if (!configured_) {
+    return;
+  }
+  // Register this thread with CNDP if required.
+  if (CndpSingleton::CndpRegisterThread("CndpQuit") < 0) {
+    LOG(ERROR) << "Register thread with CNDP failed";
+    return;
+  }
+  if (jcfg_thread_foreach(fwd_.jinfo, CndpSingleton::CndpQuit, &fwd_) < 0) {
+    LOG(WARNING) << "Error while quitting CNDP";
+  }
+  // Reset jsonc fle;
+  jsonc_file_ = "";
+  configured_ = false;
+  LOG(INFO) << "CNDP Quitted";
+}
+
+bool CndpSingleton::IsConfigured() {
+  return configured_;
+}
+
+jcfg_lport_t *CndpSingleton::GetLportFromIndex(int index) {
+  return jcfg_lport_by_index(fwd_.jinfo, index);
+}
+
+int CndpSingleton::GetNumLports() {
+  return jcfg_num_lports(fwd_.jinfo);
+}
+
+int CndpSingleton::CndpRegisterThread(const std::string &register_name) {
+  if (!cne_check_registration()) {
+    return cne_register(register_name.c_str());
+  } else {
+    return cne_id();
+  }
+}
+
+fwd_port *CndpSingleton::GetFwdPort(const jcfg_lport_t *lport) {
+  fwd_port *fport = nullptr;
+  if (lport) {
+    if (lport->priv_) {
+      fport = (fwd_port *)lport->priv_;
+    }
+  }
+  return fport;
+}
+
+int CndpSingleton::GetSocketId(char *ifname) {
+  return cne_device_socket_id(ifname);
+}
+
+int CndpSingleton::GetSocketId(uint32_t lport_id) {
+  return pktdev_socket_id(lport_id);
+}
+
+bess::PacketPool *CndpSingleton::GetCndpPacketPool(std::string umem_name,
+                                                   int socket_id) {
+  CndpPacketPoolMap::iterator pos = cndp_packet_pool_.find(umem_name);
+  if (pos == cndp_packet_pool_.end()) {
+    return nullptr;
+  } else {
+    if (pos->second && (socket_id >= 0) && (socket_id < RTE_MAX_NUMA_NODES)) {
+      CndpPacketPoolArray arr = *(pos->second);
+      return arr[socket_id];
+    } else {
+      return nullptr;
+    }
+  }
+}
+
+// CndpSingleton private member functions.
+CndpSingleton::CndpSingleton(const std::string &jsonc_file)
+    : jsonc_file_(jsonc_file) {
+  configured_ = false;
+  memset(&fwd_, 0, sizeof(fwd_));
+  if (cne_init() < 0) {
+    LOG(ERROR) << "CNDP initialization failed";
+    return;
+  }
+
+  // Parse JSONC file.
+  if (ParseFile(jsonc_file.c_str(), &fwd_) < 0) {
+    LOG(ERROR) << "CNDP parse jsonc failed";
+    return;
+  }
+  configured_ = true;
+  LOG(INFO) << "CNDP instance created";
+}
+
+int CndpSingleton::ParseFile(const char *json_file, struct fwd_info *fwd) {
+  int flags = JCFG_PARSE_FILE;
+  fwd->jinfo = jcfg_parser(flags, (const char *)json_file);
+  if (fwd->jinfo == NULL) {
+    LOG(ERROR) << "*** Did not find any configuration to use ***";
+    return -1;
+  }
+
+  if (jcfg_process(fwd->jinfo, flags, JcfgProcessCallback, fwd)) {
+    LOG(ERROR) << "*** Invalid configuration ***";
+    return -1;
+  }
+
+  if (metrics_init(fwd)) {
+    LOG(ERROR) << "*** Failed to start metrics support ***";
+    return -1;
+  }
+
+  return 0;
+}
+
+pkt_api_t CndpSingleton::GetPktApi(const char *type) {
+  if (type) {
+    size_t nlen = strnlen(type, MAX_STRLEN_SIZE);
+
+    if (!strncasecmp(type, XSKDEV_API_NAME, nlen))
+      return XSKDEV_PKT_API;
+    else if (!strncasecmp(type, PKTDEV_API_NAME, nlen))
+      return PKTDEV_PKT_API;
+  }
+
+  return UNKNOWN_PKT_API;
+}
+
+bool CndpSingleton::CreatePktmbufPool(jcfg_umem_t *umem, jcfg_info_t *j) {
+  uint32_t cache_sz;
+  char *umem_addr;
+
+  /* The UMEM object describes the total size of the UMEM space */
+  umem->mm = mmap_alloc(umem->bufcnt, umem->bufsz, (mmap_type_t)umem->mtype);
+  if (umem->mm == NULL)
+    LOG(ERROR) << " Failed to allocate mmap memory of size:"
+               << umem->bufcnt * umem->bufsz;
+
+  if (jcfg_default_get_u32(j, "cache", &cache_sz))
+    cache_sz = MEMPOOL_CACHE_MAX_SIZE;
+
+  umem_addr = (char *)mmap_addr(umem->mm);
+
+  /* Create the pktmbuf pool for each region defined */
+  for (int i = 0; i < umem->region_cnt; i++) {
+    pktmbuf_info_t *pi;
+    region_info_t *ri = &umem->rinfo[i];
+    char name[PKTMBUF_INFO_NAME_SZ] = {0};
+
+    /* Find the starting memory address in UMEM for the pktmbuf_t buffers */
+    ri->addr = umem_addr;
+    umem_addr += (ri->bufcnt * umem->bufsz);
+
+    /* Initialize a pktmbuf_info_t structure for each region in the UMEM space
+     */
+    pi = pktmbuf_pool_create(ri->addr, ri->bufcnt, umem->bufsz, cache_sz, NULL);
+    if (!pi) {
+      mmap_free(umem->mm);
+      LOG(ERROR) << "pktmbuf_pool_init() failed for region: " << i;
+      return false;
+    }
+    snprintf(name, sizeof(name), "%s-%d", umem->name, i);
+    pktmbuf_info_name_set(pi, name);
+
+    ri->pool = pi;
+  }
+
+  return true;
+}
+
+bool CndpSingleton::CreateCndpPacketPool(std::string umem_name,
+                                         size_t capacity) {
+  CndpPacketPoolArray *arr = new CndpPacketPoolArray();
+  if (arr == nullptr) {
+    LOG(ERROR) << "Error creating Cndp Packet Pool";
+    return false;
+  }
+  for (int sid = 0; sid < bess::NumNumaNodes(); sid++) {
+    bess::PacketPool *pool = new bess::DpdkPacketPool(capacity, sid);
+    if (pool == nullptr) {
+      LOG(ERROR) << "Error creating Cndp Packet Pool from Dpdk Packet pool";
+      return false;
+    }
+    (*arr)[sid] = pool;
+  }
+  cndp_packet_pool_.emplace(umem_name, arr);
+  return true;
+}
+
+uintptr_t CndpSingleton::GetUmemBaseAddr(struct rte_mempool *mp) {
+  struct rte_mempool_memhdr *memhdr;
+  memhdr = STAILQ_FIRST(&mp->mem_list);
+  if (memhdr == nullptr) {
+    return (uintptr_t) nullptr;
+  }
+  return (uintptr_t)memhdr->addr;
+}
+
+uintptr_t CndpSingleton::GetPageAlignedAddr(uintptr_t mem_addr,
+                                            uint64_t *align) {
+  uintptr_t aligned_addr = mem_addr & ~(getpagesize() - 1);
+  if (align != nullptr) {
+    *align = mem_addr - aligned_addr;
+  }
+
+  return aligned_addr;
+}
+
+int CndpSingleton::JcfgProcessCallback(jcfg_info_t *j, void *_obj, void *arg,
+                                       int idx __cne_unused) {
+  jcfg_obj_t obj;
+  struct fwd_info *f = (struct fwd_info *)arg;
+  size_t nlen;
+
+  if (!_obj)
+    return -1;
+
+  obj.hdr = (jcfg_hdr_t *)_obj;
+
+  nlen = strnlen(obj.opt->name, MAX_STRLEN_SIZE);
+
+  switch (obj.hdr->cbtype) {
+    case JCFG_APPLICATION_TYPE:
+      break;
+
+    case JCFG_DEFAULT_TYPE:
+      break;
+
+    case JCFG_OPTION_TYPE:
+      if (!strncmp(obj.opt->name, PKT_API_TAG, nlen)) {
+        if (obj.opt->val.type == STRING_OPT_TYPE) {
+          f->opts.pkt_api = obj.opt->val.str;
+          if (f->pkt_api == UNKNOWN_PKT_API)
+            f->pkt_api = CndpSingleton::GetPktApi(f->opts.pkt_api);
+        }
+      } else if (!strcmp(obj.opt->name, NO_METRICS_TAG)) {
+        if (obj.opt->val.type == BOOLEAN_OPT_TYPE)
+          f->opts.no_metrics = obj.opt->val.boolean;
+      } else if (!strcmp(obj.opt->name, NO_RESTAPI_TAG)) {
+        if (obj.opt->val.type == BOOLEAN_OPT_TYPE)
+          f->opts.no_restapi = obj.opt->val.boolean;
+      } else if (!strcmp(obj.opt->name, ENABLE_CLI_TAG)) {
+        if (obj.opt->val.type == BOOLEAN_OPT_TYPE)
+          f->opts.cli = obj.opt->val.boolean;
+      } else if (!strcmp(obj.opt->name, MODE_TAG)) {
+        if (obj.opt->val.type == STRING_OPT_TYPE) {
+          f->opts.mode = obj.opt->val.str;
+        }
+      } else if (!strncmp(obj.opt->name, UDS_PATH_TAG, nlen)) {
+        if (obj.opt->val.type == STRING_OPT_TYPE) {
+          f->xdp_uds = udsc_handshake(obj.opt->val.str);
+          if (f->xdp_uds == NULL) {
+            LOG(ERROR) << "CNDP uds handshake failed";
+            return -1;
+          }
+        }
+      }
+      break;
+
+    case JCFG_UMEM_TYPE: {
+      if (f->pkt_api == XSKDEV_PKT_API) {
+        LOG(INFO) << "Create UMEM of size = " << obj.umem->bufcnt;
+        // Create CNDP Memory Pool.
+        bool ret =
+            CreateCndpPacketPool(std::string(obj.umem->name), obj.umem->bufcnt);
+        if (!ret) {
+          LOG(ERROR) << "CNDP Mempool creation failed";
+          return -1;
+        }
+      } else {
+        bool ret = CreatePktmbufPool(obj.umem, j);
+        if (!ret) {
+          LOG(ERROR) << "Pktmbuf creation failed";
+          return -1;
+        }
+      }
+      break;
+    }
+    case JCFG_LPORT_TYPE:
+      do {
+        jcfg_lport_t *lport = obj.lport;
+        struct fwd_port *pd;
+        jcfg_umem_t *umem;
+
+        if (lport == nullptr) {
+          LOG(ERROR) << "lport is NULL";
+          return -1;
+        }
+
+        umem = lport->umem;
+        if (umem == nullptr) {
+          LOG(ERROR) << "UMEM is NULL for this lport id: " << lport->lpid;
+          return -1;
+        }
+
+        pd = (struct fwd_port *)calloc(1, sizeof(struct fwd_port));
+        if (!pd) {
+          LOG(ERROR) << "Unable to allocate fwd_port structure";
+          return -1;
+        }
+        pd->pkt_api = f->pkt_api;
+        lport->priv_ = pd;
+
+        int ret = 0;
+        // Create XSKDEV Socket.
+        if (f->pkt_api == XSKDEV_PKT_API) {
+          ret = CndpSingleton::CreateXskdevSocket(umem, lport, pd, f);
+        } else {
+          ret = CndpSingleton::CreatePktdevSocket(umem, lport, pd, f);
+        }
+        if (ret < 0) {
+          LOG(ERROR) << "AF_XDP socket creation failed";
+          return -1;
+        }
+      } while ((0));
+      break;
+
+    case JCFG_LGROUP_TYPE:
+      break;
+
+    case JCFG_THREAD_TYPE:
+      break;
+    default:
+      return -1;
+  }
+  return 0;
+}
+
+int CndpSingleton::CreateXskdevSocket(jcfg_umem_t *umem, jcfg_lport_t *lport,
+                                      struct fwd_port *pd, struct fwd_info *f) {
+  struct lport_cfg pcfg;
+  memset(&pcfg, 0, sizeof(pcfg));
+
+  // Get BESS memory pool.
+  int socket_id = CndpSingleton::GetSocketId(lport->netdev);
+  if (socket_id < 0) {
+    LOG(WARNING) << "Unable to get a valid CPU socket id. Using 0 by default";
+    socket_id = 0;
+  }
+  bess::PacketPool *bess_pool =
+      CndpSingleton::GetCndpPacketPool(lport->umem_name, socket_id);
+  if (bess_pool == nullptr) {
+    LOG(ERROR) << "Couldn't get CNDP MemPool for umem:" << lport->umem_name;
+    return -1;
+  }
+  pd->bess_pool = bess_pool;
+  rte_mempool *mp = bess_pool->pool();
+  if (mp == nullptr) {
+    LOG(ERROR) << "rte_mempool pointer is NULL";
+    return -1;
+  }
+  LOG(INFO) << "bess rte_mempool name = " << mp->name
+            << ", rte_mempool addr = " << mp
+            << ", rte_mempool id = " << mp->pool_id;
+
+  // UMEM base and aligned base address.
+  void *mp_umem_addr_base = (void *)(CndpSingleton::GetUmemBaseAddr(mp));
+  if (mp_umem_addr_base == nullptr) {
+    LOG(ERROR) << "UMEM base addr is NULL";
+    return -1;
+  }
+  uint64_t align = 0;
+  void *mp_umem_addr_base_align = (void *)CndpSingleton::GetPageAlignedAddr(
+      (uintptr_t)mp_umem_addr_base, &align);
+
+  // Framesize in UMEM.
+  uint32_t umem_framesize =
+      rte_mempool_calc_obj_size(mp->elt_size, mp->flags, NULL);
+
+  // UMEM length.
+  size_t mp_umem_len =
+      (uint64_t)mp->populated_size * (uint64_t)umem_framesize + align;
+
+  // Calculate buffer headroom.
+  size_t buf_headroom =
+      mp->header_size + sizeof(struct rte_mbuf) + rte_pktmbuf_priv_size(mp);
+
+  DLOG(INFO) << "RTE memzone Umem addr = " << mp_umem_addr_base_align;
+  DLOG(INFO) << "RTE memzone Umem len = " << mp_umem_len;
+  DLOG(INFO) << "Populated Size = " << mp->populated_size;
+  DLOG(INFO) << "Align = " << align;
+  DLOG(INFO) << "RTE memzone hugepaze sz = " << mp->mz->hugepage_sz;
+  DLOG(INFO) << "RTE memzone socket id = " << mp->mz->socket_id;
+  DLOG(INFO) << "Element size = " << mp->elt_size;
+  DLOG(INFO) << "header size = " << mp->header_size;
+  DLOG(INFO) << "trailer size = " << mp->trailer_size;
+  DLOG(INFO) << "Frame size = " << umem_framesize;
+  DLOG(INFO) << "buf_headroom = " << buf_headroom;
+  DLOG(INFO) << "Packet size = " << sizeof(bess::Packet);
+  DLOG(INFO) << "rte_mbuf size = " << sizeof(rte_mbuf);
+  DLOG(INFO) << "rte_mbuf private size = " << rte_pktmbuf_priv_size(mp);
+  DLOG(INFO) << "Num memory chunks = " << mp->nb_mem_chunks;
+  DLOG(INFO) << "Mempool max Size = " << mp->size;
+  DLOG(INFO) << "BESS packet pool size " << bess_pool->Size();
+  DLOG(INFO) << "BESS packet pool capacity " << bess_pool->Capacity();
+
+  pcfg.qid = lport->qid;
+  pcfg.bufsz = umem_framesize;
+  pcfg.rx_nb_desc = XSK_RING_PROD__DEFAULT_NUM_DESCS;
+  pcfg.tx_nb_desc = XSK_RING_CONS__DEFAULT_NUM_DESCS;
+  pcfg.pmd_opts = lport->pmd_opts;
+  pcfg.umem_addr = (char *)mp_umem_addr_base_align;
+  pcfg.umem_size = mp_umem_len;
+  pcfg.busy_timeout = lport->busy_timeout;
+  pcfg.busy_budget = lport->busy_budget;
+  pcfg.flags = lport->flags;
+  pcfg.flags |= LPORT_USER_MANAGED_BUFFERS;
+  pcfg.flags |= LPORT_UMEM_UNALIGNED_BUFFERS;
+  pcfg.flags |= (umem->shared_umem == 1) ? LPORT_SHARED_UMEM : 0;
+  pcfg.addr = (void *)mp_umem_addr_base_align;
+  pcfg.bufcnt = mp->populated_size;
+  if (!pcfg.addr) {
+    free(pd);
+    LOG(ERROR) << "fwd_port freed";
+    return -1;
+  }
+  if (lport->flags & LPORT_UNPRIVILEGED) {
+    if (f->xdp_uds)
+      pcfg.xsk_uds = f->xdp_uds;
+    else {
+      LOG(ERROR) << "UDS info struct is null";
+      return -1;
+    }
+  }
+
+  /* Setup the mempool configuration */
+  strlcpy(pcfg.pmd_name, lport->pmd_name, sizeof(pcfg.pmd_name));
+  strlcpy(pcfg.ifname, lport->netdev, sizeof(pcfg.ifname));
+  strlcpy(pcfg.name, lport->name, sizeof(pcfg.name));
+
+  pcfg.buf_mgmt.buf_arg = (void *)pd;
+  pcfg.buf_mgmt.buf_alloc = CndpSingleton::CndpBufAlloc;
+  pcfg.buf_mgmt.buf_free = CndpSingleton::CndpBufFree;
+  pcfg.buf_mgmt.buf_set_len = CndpSingleton::CndpBufSetLen;
+  pcfg.buf_mgmt.buf_set_data_len = CndpSingleton::CndpBufSetDataLen;
+  pcfg.buf_mgmt.buf_set_data = CndpSingleton::CndpBufSetData;
+  pcfg.buf_mgmt.buf_get_data_len = CndpSingleton::CndpBufGetDataLen;
+  pcfg.buf_mgmt.buf_get_data = CndpSingleton::CndpBufGetData;
+  pcfg.buf_mgmt.buf_get_addr = CndpSingleton::CndpBufGetAddr;
+  pcfg.buf_mgmt.buf_inc_ptr = CndpSingleton::CndpBufIncPtr;
+  pcfg.buf_mgmt.buf_reset = CndpSingleton::CndpBufReset;
+  pcfg.buf_mgmt.buf_headroom = buf_headroom;
+  pcfg.buf_mgmt.frame_size = pcfg.bufsz;
+  pcfg.buf_mgmt.pool_header_sz = mp->header_size;
+
+  pd->xsk = xskdev_socket_create(&pcfg);
+  if (pd->xsk == NULL) {
+    free(pd);
+    LOG(ERROR) << "xskdev_port_setup() failed";
+    return -1;
+  }
+
+  return 0;
+}
+
+int CndpSingleton::CreatePktdevSocket(jcfg_umem_t *umem, jcfg_lport_t *lport,
+                                      struct fwd_port *pd, struct fwd_info *f) {
+  struct lport_cfg pcfg;
+  memset(&pcfg, 0, sizeof(pcfg));
+
+  pcfg.qid = lport->qid;
+  pcfg.bufsz = umem->bufsz;
+  pcfg.rx_nb_desc = umem->rxdesc;
+  pcfg.tx_nb_desc = umem->txdesc;
+  pcfg.umem_addr = (char *)mmap_addr(umem->mm);
+  pcfg.umem_size = mmap_size(umem->mm, NULL, NULL);
+  pcfg.pmd_opts = lport->pmd_opts;
+  pcfg.busy_timeout = lport->busy_timeout;
+  pcfg.busy_budget = lport->busy_budget;
+  pcfg.flags = lport->flags;
+  pcfg.flags |= (umem->shared_umem == 1) ? LPORT_SHARED_UMEM : 0;
+
+  pcfg.addr = jcfg_lport_region(lport, &pcfg.bufcnt);
+  if (!pcfg.addr) {
+    free(pd);
+    return -1;
+  }
+  pcfg.pi = umem->rinfo[lport->region_idx].pool;
+  if (lport->flags & LPORT_UNPRIVILEGED) {
+    if (f->xdp_uds)
+      pcfg.xsk_uds = f->xdp_uds;
+    else
+      LOG(ERROR) << "UDS info struct is null";
+  }
+  /* Setup the mempool configuration */
+  strlcpy(pcfg.pmd_name, lport->pmd_name, sizeof(pcfg.pmd_name));
+  strlcpy(pcfg.ifname, lport->netdev, sizeof(pcfg.ifname));
+  strlcpy(pcfg.name, lport->name, sizeof(pcfg.name));
+
+  pd->lport = pktdev_port_setup(&pcfg);
+  if (pd->lport < 0) {
+    free(pd);
+    return -1;
+  }
+
+  return 0;
+}
+
+#define foreach_thd_lport(_t, _lp)                               \
+  for (int _i = 0; _i < _t->lport_cnt && (_lp = _t->lports[_i]); \
+       _i++, _lp = _t->lports[_i])
+
+int CndpSingleton::CndpQuit(jcfg_info_t *j __cne_unused, void *obj, void *arg,
+                            int idx __cne_unused) {
+  jcfg_thd_t *thd = (jcfg_thd_t *)obj;
+  jcfg_lport_t *lport;
+  struct fwd_info *fwd = (struct fwd_info *)arg;
+
+  thd->quit = 1;
+
+  if (thd->lport_cnt == 0) {
+    LOG(INFO) << "No lports attached to thread " << thd->name;
+    return 0;
+  } else
+    LOG(INFO) << "Close " << thd->lport_cnt << " lports attached to thread "
+              << thd->name;
+
+  foreach_thd_lport(thd, lport) {
+    struct fwd_port *pd = (struct fwd_port *)lport->priv_;
+    LOG(INFO) << "lport " << lport->lpid << " - " << lport->name;
+
+    if (fwd->pkt_api == XSKDEV_PKT_API) {
+      xskdev_socket_destroy(pd->xsk);
+    } else {
+      int ret = pktdev_close(pd->lport);
+      if (ret < 0) {
+        LOG(ERROR) << "port_close() returned error";
+        return ret;
+      }
+
+      if (lport->umem) {
+        int i;
+
+        for (i = 0; i < lport->umem->region_cnt; i++) {
+          pktmbuf_destroy(lport->umem->rinfo[i].pool);
+          lport->umem->rinfo[i].pool = NULL;
+        }
+        mmap_free(lport->umem->mm);
+        lport->umem->mm = NULL; /* Make sure we do not free this again */
+      }
+    }
+  }
+  // Destroy metrics.
+  metrics_destroy();
+
+  fwd->quit = 1;
+  return 0;
+}
+
+int CndpSingleton::CndpBufAlloc(void *arg, void **bufs, uint16_t nb_bufs) {
+  struct fwd_port *pd = (struct fwd_port *)arg;
+  bess::PacketPool *bess_pool = pd->bess_pool;
+  if (bess_pool == nullptr) {
+    return 0;
+  }
+  bool ret = bess_pool->AllocBulk((bess::Packet **)bufs, nb_bufs);
+  if (ret) {
+    return nb_bufs;
+  }
+  return 0;
+}
+
+void CndpSingleton::CndpBufFree(void *arg __cne_unused, void **bufs,
+                                uint16_t nb_bufs) {
+  bess::Packet **pkts = (bess::Packet **)bufs;
+  if (pkts != nullptr) {
+    for (int i = 0; i < nb_bufs; i++) {
+      bess::Packet::Free(pkts[i]);
+    }
+  }
+}
+
+void CndpSingleton::CndpBufSetDataLen(void *mb, int len) {
+  rte_mbuf *mbuf = (rte_mbuf *)mb;
+  if (mbuf) {
+    mbuf->data_len = (uint16_t)len;
+    mbuf->pkt_len = (uint16_t)len;
+  }
+}
+
+void CndpSingleton::CndpBufSetLen(void *mb, int len) {
+  rte_mbuf *mbuf = (rte_mbuf *)mb;
+  if (mbuf) {
+    mbuf->buf_len = (uint16_t)len;
+  }
+}
+
+void CndpSingleton::CndpBufSetData(void *mb, uint64_t off) {
+  rte_mbuf *mbuf = (rte_mbuf *)mb;
+  if (mbuf) {
+    mbuf->data_off = (uint16_t)off;
+  }
+}
+
+uint64_t CndpSingleton::CndpBufGetData(void *mb) {
+  rte_mbuf *mbuf = (rte_mbuf *)mb;
+  if (mbuf) {
+    uint64_t data = rte_pktmbuf_mtod(mbuf, uint64_t);
+    return data;
+  }
+  return 0;
+}
+
+uint16_t CndpSingleton::CndpBufGetDataLen(void *mb) {
+  rte_mbuf *mbuf = (rte_mbuf *)mb;
+  if (mbuf) {
+    return mbuf->data_len;
+  }
+  return 0;
+}
+
+uint64_t CndpSingleton::CndpBufGetAddr(void *mb) {
+  rte_mbuf *mbuf = (rte_mbuf *)mb;
+  return (uint64_t)(mbuf);
+}
+
+void **CndpSingleton::CndpBufIncPtr(void **mbs) {
+  rte_mbuf **mbufs = (rte_mbuf **)mbs;
+  if (mbufs) {
+    return (void **)++mbufs;
+  }
+  return nullptr;
+}
+
+void CndpSingleton::CndpBufReset(void *mb, uint32_t buf_len, size_t headroom) {
+  rte_mbuf *mbuf = reinterpret_cast<rte_mbuf *>(mb);
+  if (mbuf) {
+    mbuf->buf_len = (uint16_t)buf_len;
+    mbuf->data_off = (uint16_t)headroom;
+    mbuf->data_len = 0;
+  }
+}
+
+ADD_DRIVER(CndpPort, "cndp_port",
+           "CNDP driver to send/recv n/w packets using AF_XDP socket")

--- a/core/drivers/cndp.h
+++ b/core/drivers/cndp.h
@@ -1,0 +1,245 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2019-2021 Intel Corporation.
+ */
+
+#ifndef BESS_DRIVERS_CNDP_H_
+#define BESS_DRIVERS_CNDP_H_
+
+#include "../port.h"
+
+#include <array>
+#include <map>
+#include <string>
+
+// CNDP headers.
+#include <cne_common.h>   // for __cne_unused
+#include <cne_lport.h>    // for lport_stats_t
+#include <jcfg.h>         // for jcfg_lport_t, jcfg_info_t, jcfg_lport_foreach
+#include <packet_pool.h>  // PacketPool
+#include <pktmbuf.h>      // for pktmbuf_t
+#include <rte_mempool.h>  // rte_mempool
+#include <stdint.h>       // for uint64_t, uint32_t
+#include <uds_connect.h>  // UDS utility functions
+#include <xskdev.h>       // for xskdev_info_t
+
+#define PKT_API_TAG "pkt_api"       /**< Packet API json tag */
+#define NO_METRICS_TAG "no-metrics" /**< json tag for no-metrics */
+#define NO_RESTAPI_TAG "no-restapi" /**< json tag for no-restapi */
+#define ENABLE_CLI_TAG "cli"        /**< json tag to enable/disable CLI */
+#define MODE_TAG "mode"             /**< json tag to set the mode flag */
+#define UDS_PATH_TAG "uds_path"     /**< json tag to set the uds path */
+#define XSKDEV_API_NAME "xskdev"
+#define PKTDEV_API_NAME "pktdev"
+
+#define MAX_STRLEN_SIZE 16
+#define CNDP_MAX_BURST 256
+
+typedef enum { UNKNOWN_PKT_API, XSKDEV_PKT_API, PKTDEV_PKT_API } pkt_api_t;
+
+// Bess PacketPool
+typedef std::array<bess::PacketPool *, RTE_MAX_NUMA_NODES> CndpPacketPoolArray;
+typedef std::map<std::string, CndpPacketPoolArray *> CndpPacketPoolMap;
+
+// Forward declaration.
+class CndpSingleton;
+struct fwd_port;
+
+/// This driver binds a port to a device using CNDP/DPDK.
+class CndpPort final : public Port {
+ public:
+  /*!
+   * Initialize the CNDP port.
+   *
+   * PARAMETERS:
+   * * string jsonc_file : CNDP Jsonc configuration file.
+   * * uint32 lport_index : CNDP lport in jsonc file used to send/recv n/w pkts.
+   *
+   * EXPECTS:
+   * * Must specify both jsonc_file and lport_index.
+   */
+  CommandResponse Init(const bess::pb::CndpPortArg &arg);
+
+  /*!
+   * Reset the port.
+   */
+  void DeInit() override;
+
+  /*!
+   * Sends packets out on the device.
+   *
+   * PARAMETERS:
+   * * queue_t quid : qid is configured via jsonc and this argument is ignored
+   * * for now. This value is expected to be zero.
+   * * bess::Packet ** pkts : packets to transmit.
+   * * int cnt : number of packets in pkts to transmit.
+   *
+   * EXPECTS:
+   * * Only call this after calling Init with a device.
+   * * Don't call this after calling DeInit().
+   *
+   * RETURNS:
+   * * Total number of packets sent (<=cnt).
+   */
+  int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
+
+  /*!
+   * Receives packets from the device.
+   *
+   * PARAMETERS:
+   * * queue_t quid : qid is configured via jsonc and this argument is ignored
+   * * for now. This value is expected to be zero.
+   * * bess::Packet **pkts : buffer to store received packets in to.
+   * * int cnt : max number of packets to pull.
+   *
+   * EXPECTS:
+   * * Only call this after calling Init with a device.
+   * * Don't call this after calling DeInit().
+   *
+   * RETURNS:
+   * * Total number of packets received (<=cnt)
+   */
+  int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
+
+  /*!
+   * Copies CNDP port statistics into queue_stats datastructure (see port.h).
+   *
+   * PARAMETERS:
+   * * bool reset : if true, reset CNDP local statistics and return (do not
+   * collect stats).
+   */
+  void CollectStats(bool reset) override;
+
+  uint64_t GetFlags() const override {
+    return DRIVER_FLAG_SELF_INC_STATS | DRIVER_FLAG_SELF_OUT_STATS;
+  }
+
+  /*!
+   * Get any placement constraints that need to be met when receiving from this
+   * port.
+   */
+  placement_constraint GetNodePlacementConstraint() const override;
+
+ private:
+  // CNDP singleton instance.
+  CndpSingleton *cndp_instance_;
+
+  // jsonc file used for configuring CNDP.
+  std::string jsonc_file_;
+
+  // CNDP lport index
+  uint32_t lport_index_;
+
+  // CNDP lport.
+  jcfg_lport_t *lport_;
+
+  // CNDP fwd port.
+  fwd_port *lport_fport_;
+
+  // Bess Packet array.
+  std::array<bess::Packet *, bess::PacketBatch::kMaxBurst> pkt_recv_vector_;
+
+  // CNDP stats.
+  lport_stats_t cndp_stats_;
+
+  // CPU socket id for this lport.
+  int lport_socket_id_;
+
+  bool ReplenishRecvVector(int cnt);
+  void FreeRecvVector();
+  void CndpStats(bool reset);
+  uint16_t XskdevRecvPackets(struct fwd_port *fport, bess::Packet **pkts,
+                             int cnt);
+  uint16_t PktdevRecvPackets(struct fwd_port *fport, bess::Packet **pkts,
+                             int cnt);
+  uint16_t PktdevSendPackets(struct fwd_port *fport, bess::Packet **pkts,
+                             int cnt);
+  uint16_t XskdevSendPackets(struct fwd_port *fport, bess::Packet **pkts,
+                             int cnt);
+};
+
+struct fwd_port {
+  union {
+    xskdev_info_t *xsk; /**< XSKDEV information pointer */
+    int lport;          /**< PKTDEV lport id */
+  };
+  union {
+    bess::PacketPool *bess_pool;      /**< BESS pool pointer */
+    pktmbuf_t *mbufs[CNDP_MAX_BURST]; /**< TX/RX mbufs array */
+  };
+  pkt_api_t pkt_api; /**< The packet API mode */
+  uint64_t ipackets; /**< previous rx packets */
+  uint64_t opackets; /**< previous tx packets */
+  uint64_t ibytes;   /**< previous rx bytes */
+  uint64_t obytes;   /**< previous tx bytes */
+};
+
+class CndpSingleton {
+ public:
+  static CndpSingleton &GetInstance(const std::string &jsonc_file);
+  CndpSingleton(CndpSingleton const &) = delete;
+  void operator=(CndpSingleton const &) = delete;
+  void Quit();
+  bool IsConfigured();
+  jcfg_lport_t *GetLportFromIndex(int index);
+  int GetNumLports();
+  static int CndpRegisterThread(const std::string &register_name);
+  fwd_port *GetFwdPort(const jcfg_lport_t *lport);
+  static int GetSocketId(char *ifname);
+  static int GetSocketId(uint32_t lport_id);
+  static bess::PacketPool *GetCndpPacketPool(std::string umem_name,
+                                             int socket_id);
+
+ private:
+  std::string jsonc_file_;
+  bool configured_;
+  static CndpPacketPoolMap cndp_packet_pool_;
+  static const size_t kDefaultCapacity = (1 << 17) - 1;  // 128k - 1
+
+  struct app_options {
+    bool no_metrics; /**< Enable metrics*/
+    bool no_restapi; /**< Enable REST API*/
+    bool cli;        /**< Enable Cli*/
+    char *mode;      /**< Application mode*/
+    char *pkt_api;   /**< The pkt API mode */
+  };
+
+  struct fwd_info {
+    jcfg_info_t *jinfo;      /**< JSON-C configuration */
+    uint32_t flags;          /**< Application set of flags */
+    volatile int quit;       /**< flags to start and stop the application */
+    struct app_options opts; /**< Application options*/
+    pkt_api_t pkt_api;       /**< The packet API mode */
+    uds_info_t *xdp_uds;     /**< UDS to get xsk map fd from */
+  };
+
+  struct fwd_info fwd_;
+
+  CndpSingleton(const std::string &jsonc_file);
+  int ParseFile(const char *json_file, struct fwd_info *fwd);
+  static pkt_api_t GetPktApi(const char *type);
+  static int CreateXskdevSocket(jcfg_umem_t *umem, jcfg_lport_t *lport,
+                                struct fwd_port *pd, struct fwd_info *f);
+  static int CreatePktdevSocket(jcfg_umem_t *umem, jcfg_lport_t *lport,
+                                struct fwd_port *pd, struct fwd_info *f);
+  static int JcfgProcessCallback(jcfg_info_t *j __cne_unused, void *_obj,
+                                 void *arg, int idx __cne_unused);
+  static int CndpQuit(jcfg_info_t *j __cne_unused, void *obj, void *arg,
+                      int idx __cne_unused);
+  static uintptr_t GetUmemBaseAddr(struct rte_mempool *mp);
+  static uintptr_t GetPageAlignedAddr(uintptr_t mem_addr, uint64_t *align);
+  static int CndpBufAlloc(void *arg, void **bufs, uint16_t nb_bufs);
+  static void CndpBufFree(void *arg, void **bufs, uint16_t nb_bufs);
+  static void CndpBufSetDataLen(void *mb, int len);
+  static void CndpBufSetLen(void *mb, int len);
+  static void CndpBufSetData(void *mb, uint64_t off);
+  static uint64_t CndpBufGetData(void *mb);
+  static uint16_t CndpBufGetDataLen(void *mb);
+  static uint64_t CndpBufGetAddr(void *mb);
+  static void **CndpBufIncPtr(void **mbs);
+  static void CndpBufReset(void *mb, uint32_t buf_len, size_t headroom);
+  static bool CreateCndpPacketPool(std::string umem_name,
+                                   size_t capacity = kDefaultCapacity);
+  static bool CreatePktmbufPool(jcfg_umem_t *umem, jcfg_info_t *j);
+};
+
+#endif  // BESS_DRIVERS_CNDP_H_

--- a/core/pktbatch.h
+++ b/core/pktbatch.h
@@ -69,7 +69,7 @@ class PacketBatch {
     bess::utils::CopyInlined(pkts_, src->pkts_, cnt_ * sizeof(Packet *));
   }
 
-  static const size_t kMaxBurst = 32;
+  static const size_t kMaxBurst = 64;
 
  private:
   int cnt_;

--- a/env/Dockerfile-cndp
+++ b/env/Dockerfile-cndp
@@ -1,12 +1,17 @@
-# SPDX-License-Identifier: Apache-2.0
-# Copyright 2020-present Open Networking Foundation
-# Copyright 2019 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2022 Intel Corporation
+#
 # vim: syntax=dockerfile
 
+# Build command from bess root directory to build besscndp docker image
+# docker build --build-arg http_proxy=$http_proxy \
+# --build-arg https_proxy=$http_proxy --build-arg no_proxy="$no_proxy" \
+# -t besscndp -f env/Dockerfile-cndp .
+
 ARG BASE_IMAGE=ubuntu:focal
-# Install CNDP dependencies and build CNDP.
 FROM ${BASE_IMAGE} AS cndp-build
 
+# Install CNDP dependencies and build CNDP.
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -48,7 +53,7 @@ WORKDIR /
 RUN git clone https://github.com/CloudNativeDataPlane/cndp.git
 WORKDIR /cndp
 # Use version of CNDP tested with BESS
-RUN git checkout d5ce4b9edc2e7ddb46a61b395deffafaf11a0500
+RUN git checkout 19d74af9b37c4150a3a054a394f7f13eb95ed0b8
 # Build and install CNDP shared libraries
 RUN make && make install
 # Build and install CNDP static libraries
@@ -88,32 +93,42 @@ COPY --from=cndp-build /usr/include/xdp/ /usr/include/xdp/
 # Set CNDP PKG_CONFIG_PATH
 ENV PKG_CONFIG_PATH=/usr/lib64/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig
 
+# Install BESS
 RUN echo "APT::Install-Recommends false;" >> /etc/apt/apt.conf.d/00recommends && \
 	echo "APT::Install-Suggests false;" >> /etc/apt/apt.conf.d/00recommends && \
 	echo "APT::AutoRemove::RecommendsImportant false;" >> /etc/apt/apt.conf.d/00recommends && \
 	echo "APT::AutoRemove::SuggestsImportant false;" >> /etc/apt/apt.conf.d/00recommends
 
-COPY build-dep.yml /tmp/
-COPY kmod.yml /tmp/
-COPY ci.yml /tmp/
+COPY env/build-dep.yml /tmp/
+COPY env/kmod.yml /tmp/
+COPY env/ci.yml /tmp/
 
 # Install dependency packages with Ansible
 RUN apt-get -q update && \
-	apt-get install -y ansible curl && \
+	apt-get install -y ansible curl git sudo libgraph-easy-perl python-is-python3 && \
         ansible-playbook /tmp/ci.yml -i "localhost," -c local && \
 	apt-get purge -y ansible && \
 	apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists
-RUN update-alternatives --install /usr/local/bin/python python /usr/bin/python3 3
-RUN mkdir -p /build/bess
+RUN python3 -m pip install --upgrade pip && python3 -m pip install grpcio scapy protobuf==3.20.0 flask pyroute2
 
-# Build DPDK testpmd (used in bessctl samples)
-ARG BESS_DPDK_BRANCH=dpdk-2011-focal
-RUN cd /build/bess && \
-	curl -s -L https://github.com/omec-project/bess/archive/${BESS_DPDK_BRANCH}.tar.gz | tar zx --strip-components=1 && \
-	./build.py dpdk && \
-	cp /build/bess/deps/dpdk-20.11.3/build/app/dpdk-testpmd /usr/local/bin/ && \
-	rm -rf /build/bess
+RUN mkdir -p /build/bess
+RUN mkdir -p /build/bess/log
+
+
+# Copy required files and build bess
+WORKDIR /build/bess
+COPY bessctl bessctl
+COPY bin bin
+COPY core core
+COPY deps/*.patch deps/
+COPY env env
+COPY protobuf protobuf
+COPY pybess pybess
+COPY sample_plugin sample_plugin
+COPY build.py container_build.py install_git_hooks.sh ./
+RUN ./build.py bess
+RUN cp /build/bess/deps/dpdk-20.11.3/build/app/dpdk-testpmd /usr/local/bin/
 
 ENV CCACHE_DIR=/tmp/ccache
 ENV CCACHE_COMPRESS=true

--- a/protobuf/ports/port_msg.proto
+++ b/protobuf/ports/port_msg.proto
@@ -1,4 +1,5 @@
 // Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// Copyright (c) 2020-2022 Intel Corporation.
 // All rights reserved.
 //
 // SPDX-License-Identifier: BSD-3-Clause
@@ -88,4 +89,12 @@ message VPortArg {
   uint64 tx_outer_tci = 7;
   bool loopback = 8;
   repeated string ip_addrs = 9;
+}
+
+message CndpPortArg {
+  /// CNDP JSONC configuration absolute file path.
+  string jsonc_file = 1;
+
+  /// lport index.
+  uint32 lport_index = 2;
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ scapy
 flask
 grpcio
 protobuf==3.20
+pyroute2


### PR DESCRIPTION
- CNDP BESS port to send/receive n/w packets using AF_XDP socket.
- Modify Bess core Makefile to build CNDP port driver.
- Dockerfile to build BESS with CNDP.
- Add "CndpPortArg" in port_msg.proto file to initialize Bess CNDP port.
- Use external BESS PacketPool (rte_mempool/rte_mbuf) with CNDP xskdev.
- Example scripts to test Bess CNDP port.
- ReadMe file to build docker image and run BESS CNDP example scripts.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>