### PR TITLE
Build new image taking into account new dependencies (such as CNDP)

### DIFF
--- a/env/rebuild_images.py
+++ b/env/rebuild_images.py
@@ -60,7 +60,7 @@ def run_cmd(cmd, shell=False):
 def build(env):
     base = imgs[env]['base']
     tag_suffix = imgs[env]['tag_suffix']
-    bess_dpdk_branch = os.getenv('BESS_DPDK_BRANCH', 'master')
+    bess_dpdk_branch = os.getenv('BESS_DPDK_BRANCH', 'dpdk-2011-focal')
     version = time.strftime('%y%m%d')
 
     run_cmd('docker build '
@@ -89,10 +89,7 @@ def main(argv):
 
     version, tag_suffix = build(argv[1])
 
-    try:
-        prompt = raw_input  # Python 2
-    except NameError:
-        prompt = input      # Python 3
+    prompt = input      # Python 3
 
     if prompt('Do you wish to push the image? [y/N] ').lower() in ['y', 'yes']:
         push(version, tag_suffix)


### PR DESCRIPTION
This PR updates the rebuild_images.py script to properly take into account the dependencies for the recently merged CNDP integration