### PR TITLE
Update pktbatch.h

### DIFF
--- a/core/pktbatch.h
+++ b/core/pktbatch.h
@@ -67,7 +67,7 @@ class PacketBatch {
     bess::utils::CopyInlined(pkts_, src->pkts_, cnt_ * sizeof(Packet *));
   }
 
-  inline static const size_t kMaxBurst = 32;
+  inline static const size_t kMaxBurst = 64;
 
  private:
   int cnt_;


### PR DESCRIPTION
Change default max burst size to align with current value in dpdk-2011-focal branch