### PR TITLE
Ansible-related updates

### DIFF
--- a/env/build-dep.yml
+++ b/env/build-dep.yml
@@ -1,10 +1,6 @@
 - hosts: all
   tags: build-dep
   tasks:
-    - apt_repository: repo='ppa:ubuntu-toolchain-r/test' codename={{ ansible_distribution_release }}
-      become: true
-      when: ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int < 18
-
     - name: Install APT prerequisite packages
       apt:
         name:
@@ -44,7 +40,6 @@
           - ninja
         executable: pip3
 
-    # pre-packaged meat for Bionic Beaver or higher
     - name: Install gRPC and its requirements (apt)
       apt:
         name:
@@ -53,41 +48,7 @@
           - libgrpc++-dev
           - libprotobuf-dev
           - protobuf-compiler-grpc
-      when: ansible_distribution == 'Debian' or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 18)
-
-    # for Ubuntu < 18.04, grpc has to be installed manually
-    - name: Install gRPC and its requirements (from source)
-      block:
-        - name: Install grpc denepdencies
-          apt:
-            name:
-              - autoconf
-              - libtool
-              - cmake
-          become: true
-
-        - name: Download gRPC
-          git: repo=https://github.com/google/grpc dest=/tmp/grpc accept_hostkey=yes version=v1.3.2
-
-        - name: Compile gRPC and its dependencies
-          shell: make -j`nproc` EXTRA_CFLAGS='-Wno-error' HAS_SYSTEM_PROTOBUF=false chdir=/tmp/grpc
-
-        - name: Install gRPC
-          shell: make install chdir=/tmp/grpc
-
-        - name: Install protobuf
-          shell: make install chdir=/tmp/grpc/third_party/protobuf
-
-        - name: Generate makefile for libbenchmark
-          shell: cmake . chdir=/tmp/grpc/third_party/benchmark
-
-        - name: Install libbenchmark
-          shell: make install chdir=/tmp/grpc/third_party/benchmark
-
-        - name: sudo ldconfig
-          shell: ldconfig
       become: true
-      when: ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int < 18
 
     - name: BESS build dependencies installed
       debug:

--- a/env/build-dep.yml
+++ b/env/build-dep.yml
@@ -5,29 +5,36 @@
       become: true
       when: ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int < 18
 
-    - name: Install prerequisite packages
-      apt: name={{item}} update_cache=yes
+    - name: Install APT prerequisite packages
+      apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - g++
+          - make
+          - libunwind8-dev
+          - liblzma-dev
+          - zlib1g-dev
+          - libpcap-dev
+          - libssl-dev
+          - libnuma-dev
+          - libgflags-dev
+          - libgoogle-glog-dev
+          - libgtest-dev
+          - python3
+          - python3-apt
+          - python3-pip
+          - pkg-config
+        update_cache: yes
       become: true
-      with_items:
-        - apt-transport-https
-        - ca-certificates
-        - g++
-        - g++-7
-        - make
-        - libunwind8-dev
-        - liblzma-dev
-        - zlib1g-dev
-        - libpcap-dev
-        - libssl-dev
-        - libnuma-dev
-        - libgflags-dev
-        - libgoogle-glog-dev
-        - libgtest-dev
-        - python3
-        - python3-pip
-        - python3-pyelftools
-        - python3-setuptools
-        - pkg-config
+
+    - name: Install PIP prerequisite packages
+      become: true
+      pip:
+        name:
+          - pyelftools
+          - setuptools
+        executable: pip3
 
     - name: Install DPDK build system
       become: true
@@ -39,26 +46,25 @@
 
     # pre-packaged meat for Bionic Beaver or higher
     - name: Install gRPC and its requirements (apt)
-      apt: name={{item}}
-      become: true
-      with_items:
-        - libc-ares-dev
-        - libbenchmark-dev
-        - libgrpc++-dev
-        - libprotobuf-dev
-        - protobuf-compiler-grpc
+      apt:
+        name:
+          - libc-ares-dev
+          - libbenchmark-dev
+          - libgrpc++-dev
+          - libprotobuf-dev
+          - protobuf-compiler-grpc
       when: ansible_distribution == 'Debian' or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 18)
 
     # for Ubuntu < 18.04, grpc has to be installed manually
     - name: Install gRPC and its requirements (from source)
       block:
         - name: Install grpc denepdencies
-          apt: name={{item}}
+          apt:
+            name:
+              - autoconf
+              - libtool
+              - cmake
           become: true
-          with_items:
-            - autoconf
-            - libtool
-            - cmake
 
         - name: Download gRPC
           git: repo=https://github.com/google/grpc dest=/tmp/grpc accept_hostkey=yes version=v1.3.2

--- a/env/ci.yml
+++ b/env/ci.yml
@@ -12,9 +12,10 @@
   tags: ci
   tasks:
     - name: Install additional compilers for the build container
-      apt: name={{item}} update_cache=yes
+      apt:
+        name:
+          - g++
+          - clang
+          - ccache
+        update_cache: yes
       become: true
-      with_items:
-        - g++-8
-        - clang-6.0
-        - ccache

--- a/env/dev.yml
+++ b/env/dev.yml
@@ -6,15 +6,17 @@
   tags: dev
   tasks:
     - name: Install recommended packages for developers
-      apt: name={{item}} update_cache=yes
+      apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - git
+          - gdb
+          - linux-tools-common
+          - vim
+          - nano
+          - lcov
+          - python-autopep8
+          - graphviz
+        update_cache: yes
       become: true
-      with_items:
-        - apt-transport-https
-        - ca-certificates
-        - git
-        - gdb
-        - linux-tools-common
-        - vim
-        - lcov
-        - python-autopep8
-        - graphviz

--- a/env/docker.yml
+++ b/env/docker.yml
@@ -1,5 +1,5 @@
 # Docker is an optional package.
-# Some BESS examples make uee of Docker to demonstrate container networking.
+# Some BESS examples make use of Docker to demonstrate container networking.
 - hosts: all
   tags: docker
   tasks:
@@ -11,5 +11,9 @@
       become: true
 
     - name: Install Docker
-      apt: name=docker-ce state=latest update_cache=yes
+      apt:
+        name:
+          - docker-ce
+        state: latest
+        update_cache: yes
       become: true

--- a/env/kmod.yml
+++ b/env/kmod.yml
@@ -2,11 +2,13 @@
   tags: kmod
   tasks:
     - name: Install list of packages (this step may take a long time)
-      apt: name={{item}} state=latest update_cache=yes
+      apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - build-essential
+          - linux-headers-generic
+          - linux-headers-{{ansible_kernel}}
+        state: latest
+        update_cache: yes
       become: true
-      with_items:
-        - apt-transport-https
-        - ca-certificates
-        - build-essential
-        - linux-headers-generic
-        - linux-headers-{{ansible_kernel}}

--- a/env/runtime.yml
+++ b/env/runtime.yml
@@ -2,15 +2,16 @@
   tags: runtime
   tasks:
     - name: Install prerequisite packages
-      apt: name={{item}} update_cache=yes
+      apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - python
+          - python-pip
+          - libgraph-easy-perl
+          - tcpdump
+        update_cache: yes
       become: true
-      with_items:
-        - apt-transport-https
-        - ca-certificates
-        - python
-        - python-pip
-        - libgraph-easy-perl
-        - tcpdump
 
     - name: Install list of Python packages
       pip:
@@ -29,7 +30,10 @@
       register: def_hugepage_size
 
     - name: Enable huge pages
-      sysctl: name=vm.nr_hugepages value={{ num_nodes.stdout|int * 512 }} sysctl_set=yes
+      ansible.posix.sysctl:
+        name: vm.nr_hugepages
+        value: {{ num_nodes.stdout|int * 512 }}
+        sysctl_set: yes
       when: "{{ def_hugepage_size.stdout.find('2048 kB') != -1 }}"
       become: true
 
@@ -38,6 +42,10 @@
       failed_when: hugetlbfs_mounted.rc == 2
 
     - name: Mount up /mnt/huge
-      mount: name=/mnt/huge fstype=hugetlbfs src=none state=mounted
+      mount:
+        name: /mnt/huge
+        fstype: hugetlbfs
+        src: none
+        state: mounted
       when: hugetlbfs_mounted.rc == 1
       become: true

--- a/env/vagrant.yml
+++ b/env/vagrant.yml
@@ -4,20 +4,36 @@
   tags: vagrant
   tasks:
     - name: Reboot after 20 sec on kernel panic
-      sysctl: name=kernel.panic value=20 sysctl_set=yes
+      ansible.posix.sysctl:
+        name: kernel.panic
+        value: 20
+        sysctl_set: yes
       become: true
 
     - name: Panic on oops
-      sysctl: name=kernel.panic_on_oops value=1 sysctl_set=yes
+      ansible.posix.sysctl:
+        name: kernel.panic_on_oops
+        value: 1
+        sysctl_set: yes
       become: true
 
-    - user: name=vagrant groups=adm,docker append=yes
+    - user:
+        name: vagrant
+        groups: adm,docker
+        append: yes
       become: true
 
     - name: Bind /opt/bess as ~/bess
-      mount: name=/home/vagrant/bess fstype=none opts=bind src=/opt/bess state=mounted
+      mount:
+        name: /home/vagrant/bess
+        fstype: none
+        opts: bind
+        src: /opt/bess
+        state: mounted
       become: true
 
     - name: Set PATH
-      lineinfile: dest=/etc/environment line='PATH="/opt/bess/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"'
+      lineinfile:
+        dest: /etc/environment
+        line: 'PATH="/opt/bess/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"'
       become: true


### PR DESCRIPTION
This PR does the following:
1. Updates Ansible files (*.yml) to follow the format of the newer Ansible versions
2. Remove dependency versions such that newer versions of APT packages can be used
3. Remove support for older Ubuntu versions (<18.04)

This PR was tested deploying the UPF in standalone mode with AF_PACKET and DPDK modes. Additionally, the changes were tested deploying the UPF in AF_PACKET mode as part of OnRamp.