### PR TITLE
Align copyright/license header with latest reuse version(s)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 ---
 # BasedOnStyle:  Google
 AccessModifierOffset: -1

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 codecov:
   branch: master  # base branch for delta computation
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 *.bess  linguist-language=Python

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: reuse lint
-        uses: fsfe/reuse-action@v1
+        uses: fsfe/reuse-action@v3
 
   fossa-check:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Temporary/hidden files
 .*
 *.dump

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 : ${CXX_FORMAT:=clang-format}
 : ${PY_FORMAT:=autopep8}
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,9 +1,0 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: bess
-Upstream-Contact: OMEC Developers <omec-dev@opennetworking.org>
-Source: https://github.com/omec-project/bess
-
-Files: .codecov.yml .gitattributes .gitignore CONTRIBUTING.md README.md requirements.txt .hooks/pre-commit bessctl/server.py bessctl/conf/port/vhost/README.md bessctl/conf/samples/mpls_test.bess bessctl/conf/samples/tc/wfs_double.bess bessctl/module_tests/*.pcap bessctl/static/*.* .clang-format core/.gitignore core/coverage core/*.suppress core/memory*.* core/packet_pool.* core/kmod/.clang-format core/kmod/.gitignore core/kmod/install core/pb/.gitignore core/resume_hooks/README.md core/testdata/test-pktcaptures/*.bytes core/testdata/test-pktcaptures/*.pcap deps/bpf_validate.patch deps/ethdev_include.patch doxygen/README.md doxygen/bess.dox env/*.yml env/Dockerfile env/README.md env/Vagrantfile pybess/**/__init__.py pybess/**/.gitignore sample_plugin/README.md
-Copyright: 2016-2017, Nefeli Networks, Inc.
-Copyright: 2017, The Regents of the University of California.
-License: BSD-3-Clause

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 # How To Contribute
 Thank you for your interest in BESS!  We welcome new contributions.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 ## BESS (Berkeley Extensible Software Switch)
 
 BESS (formerly known as [SoftNIC](https://www2.eecs.berkeley.edu/Pubs/TechRpts/2015/EECS-2015-155.html)) is a modular framework for software switches. BESS itself is *not* a virtual switch; it is neither pre-configured nor hard-coded to provide particular functionality, such as Ethernet bridging or OpenFlow-driven switching. Instead, you (or an external controller) can *configure* your own packet processing datapath by composing small "modules". While the basic concept is similar to [Click](http://read.cs.ucla.edu/click/click), BESS does not sacrifice performance for programmability.

--- a/bessctl/conf/port/vhost/README.md
+++ b/bessctl/conf/port/vhost/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 This example is to demonstrate how to connect BESS to VMs or containers.
 
 ### Requirements

--- a/bessctl/conf/port/vhost/launch_container.py
+++ b/bessctl/conf/port/vhost/launch_container.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright (c) 2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/bessctl/conf/port/vhost/launch_vm.py
+++ b/bessctl/conf/port/vhost/launch_vm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright (c) 2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/bessctl/conf/samples/mpls_test.bess
+++ b/bessctl/conf/samples/mpls_test.bess
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 import scapy.all as scapy
 
 # MPLS layer addition to scapy
@@ -9,11 +13,11 @@ class MPLS(scapy.Packet):
                 scapy.BitField("bottom_of_label_stack", 1, 1),
                 scapy.ByteField("TTL", 255)
         ]
-        
+
 scapy.bind_layers(scapy.Ether, MPLS, type = 0x8847)
 scapy.bind_layers(MPLS, MPLS, bottom_of_label_stack = 0)
 scapy.bind_layers(MPLS, scapy.IP)
-        
+
 eth = scapy.Ether(src='02:1e:67:9f:4d:ae', dst='06:16:3e:1b:72:32')
 mpls = MPLS(label = 0xFFFFF, TTL = 255, bottom_of_label_stack=1)
 ip = scapy.IP(src='192.168.0.1', dst='10.0.0.1')

--- a/bessctl/conf/samples/tc/wfs_double.bess
+++ b/bessctl/conf/samples/tc/wfs_double.bess
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Test WeightedFairscheduler's accuracy on a simple tree pipeline
 # Works correctly, if internal variables of WFS are represented as
 # doubles.

--- a/bessctl/module_tests/ipv4frags.pcap.license
+++ b/bessctl/module_tests/ipv4frags.pcap.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause

--- a/bessctl/server.py
+++ b/bessctl/server.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 import json
 
 from flask import Flask, jsonify

--- a/bessctl/static/graph.html
+++ b/bessctl/static/graph.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/bessctl/static/pipeline.js
+++ b/bessctl/static/pipeline.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+// SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+// SPDX-License-Identifier: BSD-3-Clause
+
 // colorscheme:
 // #01295f cool black
 // #437f97 queen blue

--- a/build.py
+++ b/build.py
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2014-2017, The Regents of the University of California.
 # Copyright (c) 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/container_build.py
+++ b/container_build.py
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2014-2016, The Regents of the University of California.
 # Copyright (c) 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
 # Copyright (c) 2017, Cloudigo.
 # All rights reserved.
 #

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 extra*.mk
 
 # Executables

--- a/core/coverage
+++ b/core/coverage
@@ -1,5 +1,9 @@
 #!/bin/sh -e
 
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 args=${1:-"run serve"}
 
 for arg in $args;

--- a/core/kmod/.clang-format
+++ b/core/kmod/.clang-format
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Linux kernel style for C
 BasedOnStyle: LLVM
 IndentWidth: 8

--- a/core/kmod/.gitignore
+++ b/core/kmod/.gitignore
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 .*.cmd
 .tmp_versions

--- a/core/kmod/install
+++ b/core/kmod/install
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 sudo killall -q bessd
 sleep 1
 if lsmod | grep -q bess; then

--- a/core/lsan.suppress
+++ b/core/lsan.suppress
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # This file contains a list of functions/files that should be ignored by
 # clang's LeakSanitizer. For more details, see:
 # https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer

--- a/core/memory.cc
+++ b/core/memory.cc
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+// SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "memory.h"
 
 #include <fcntl.h>

--- a/core/memory.h
+++ b/core/memory.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+// SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #ifndef BESS_MEMORY_H_
 #define BESS_MEMORY_H_
 

--- a/core/memory_test.cc
+++ b/core/memory_test.cc
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+// SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "memory.h"
 
 #include <glog/logging.h>

--- a/core/packet_pool.cc
+++ b/core/packet_pool.cc
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+// SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "packet_pool.h"
 
 #include <sys/mman.h>

--- a/core/packet_pool.h
+++ b/core/packet_pool.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+// SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #ifndef BESS_PACKET_POOL_H_
 #define BESS_PACKET_POOL_H_
 

--- a/core/pb/.gitignore
+++ b/core/pb/.gitignore
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 *
 !.gitignore

--- a/core/resume_hooks/README.md
+++ b/core/resume_hooks/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 # Resume Hooks
 Resume hooks allow you to run arbitrary code immediately before a worker is
 resumed. They can be configured with the `ConfigureResumeHook()` RPC.

--- a/core/testdata/test-pktcaptures/tcpflow-http-3.bytes.license
+++ b/core/testdata/test-pktcaptures/tcpflow-http-3.bytes.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause

--- a/core/testdata/test-pktcaptures/tcpflow-http-3.pcap.license
+++ b/core/testdata/test-pktcaptures/tcpflow-http-3.pcap.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause

--- a/core/ubsan.suppress
+++ b/core/ubsan.suppress
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # This file contains a list of functions/files that should be ignored by
 # clang's UndefinedBehaviorSanitizer. For more details, see:
 # https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html

--- a/deps/bpf_validate.patch.license
+++ b/deps/bpf_validate.patch.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-FileCopyrightText: 2024, Intel Corporation
+SPDX-License-Identifier: BSD-3-Clause

--- a/doxygen/README.md
+++ b/doxygen/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 ### How to generate BESS code documentation
 
 * Install doxygen (sudo apt-get install doxygen)

--- a/doxygen/bess.dox
+++ b/doxygen/bess.dox
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Doxyfile 1.8.12
 
 # This file describes the settings to be used by the documentation system

--- a/env/README.md
+++ b/env/README.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-FileCopyrightText: 2024, Intel Corporation
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 This directory contains various scripts to help users start trying BESS without
 much pain. There is a Vagrant script that allows you to bring up a VM that is
 pre-configured with all required dependencies. There are also Ansible scripts in

--- a/env/Vagrantfile
+++ b/env/Vagrantfile
@@ -1,5 +1,10 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 [
   { :name => "vagrant-reload", :version => ">= 0.0.1" },
   { :name => "vagrant-cachier", :version => ">= 1.2.1"}

--- a/env/build-dep.yml
+++ b/env/build-dep.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
 - hosts: all
   tags: build-dep
   tasks:

--- a/env/ci.yml
+++ b/env/ci.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Container provisioning for building BESS on Travis CI,
 # with various compilers and configurations
 

--- a/env/dev.yml
+++ b/env/dev.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
 - import_playbook: ci.yml
 - import_playbook: docker.yml
 - import_playbook: runtime.yml

--- a/env/docker.yml
+++ b/env/docker.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Docker is an optional package.
 # Some BESS examples make use of Docker to demonstrate container networking.
 - hosts: all

--- a/env/kmod.yml
+++ b/env/kmod.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
 - hosts: all
   tags: kmod
   tasks:

--- a/env/rebuild_images.py
+++ b/env/rebuild_images.py
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2014-2016, The Regents of the University of California.
 # Copyright (c) 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/env/runtime.yml
+++ b/env/runtime.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
 - hosts: all
   tags: runtime
   tasks:

--- a/env/vagrant.yml
+++ b/env/vagrant.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
 - import_playbook: dev.yml
 
 - hosts: all

--- a/pybess/builtin_pb/.gitignore
+++ b/pybess/builtin_pb/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Ignore everything first, then un-ignore - note that
 # we must explicitly un-ignore the subdirectory, then
 # ignore everything in it, then un-ignore the __init__.py

--- a/pybess/builtin_pb/__init__.py
+++ b/pybess/builtin_pb/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
 

--- a/pybess/plugin_pb/.gitignore
+++ b/pybess/plugin_pb/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # see ../builtin_pb/.gitignore
 *
 !.gitignore

--- a/pybess/plugin_pb/__init__.py
+++ b/pybess/plugin_pb/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-License-Identifier: BSD-3-Clause
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+# SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+# SPDX-FileCopyrightText: 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
 coverage
 grpcio
 pyroute2

--- a/sample_plugin/README.md
+++ b/sample_plugin/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016-2017, Nefeli Networks, Inc.
+SPDX-FileCopyrightText: 2017, The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 ## Sample plugin
 
 This is just a sample of a way to add plugins to BESS.


### PR DESCRIPTION
This PR only moves the copyright/license from `.reuse/dep5` into the respective files. This is needed for us to be able to use newer versions of `reuse` (i.e., v2 and v3).

NO functional changes were made