### PR TITLE
Add (optional) argument to pass allow PCI to DPDK

### DIFF
--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -45,7 +45,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <sstream>
 #include <string>
+#include <vector>
 
 #include "memory.h"
 #include "opts.h"
@@ -127,6 +129,22 @@ void init_eal(int dpdk_mb_per_socket, std::string nonworker_corelist) {
 
   if (FLAGS_iova != "")
     rte_args.Append({"--iova", FLAGS_iova});
+
+  if (FLAGS_allow != "") {
+    LOG(INFO) << "FLAGS_allow value(s): " << FLAGS_allow;
+    std::istringstream iss(FLAGS_allow);
+    std::vector<std::string> pciAddresses;
+    std::string temp;
+
+    while (std::getline(iss, temp, ',')) {
+      pciAddresses.push_back(temp);
+    }
+
+    for (const std::string &address : pciAddresses) {
+      LOG(INFO) << "PCI address is: " << address;
+      rte_args.Append({"--allow", address});
+    }
+  }
 
   if (dpdk_mb_per_socket <= 0) {
     rte_args.Append({"--no-huge"});

--- a/core/opts.h
+++ b/core/opts.h
@@ -53,5 +53,6 @@ DECLARE_bool(no_crashlog);
 DECLARE_int32(buffers);
 DECLARE_bool(dpdk);
 DECLARE_string(iova);
+DECLARE_string(allow);
 
 #endif  // BESS_OPTS_H_


### PR DESCRIPTION
Add (optional) argument `allow` to BESS that is used by DPDK `--allow` to indicate what PCI addresses DPDK is allowed to use. This is useful when launching multiple UPF/BESS instances and we know that the UPF only requires 2 VFs/ports in the same machine. However, by default, DPDK will open all ports. So, without this restriction (`allow`), a 2nd instance will fail to launch because it will see there is no VFs available to use.

The expected input format is:
`bessd -f --grpc_url=0.0.0.0:10514`
or
`bessd -f --allow="" --grpc_url=0.0.0.0:10514`
or
`bessd -f --allow=0000:16:01.5,0000:16:01.0 --grpc_url=0.0.0.0:10514`
or
`bessd -f --allow=0000:16:01.5,0000:16:01.0, --grpc_url=0.0.0.0:10514` (Note that last "comma" at the end of the allow value)

The changes have been tested deploying the UPF in standalone mode (no `--allow` argument passed) and deploying the UPF as part of AiaB/OnRamp deploying multiple UPF instances and passing the `--allow` argument