### PR TITLE
fix: prevent bessctl hanging on SystemExit

### DIFF
--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -164,7 +164,7 @@ def run_cli(instream=sys.stdin):
     if cli.stop_loop:
         if cli.last_cmd:
             cli.ferr.write('  Command failed: %s\n' % cli.last_cmd)
-        sys.exit(1)
+        os._exit(1)
 
 
 def main():


### PR DESCRIPTION
This PR aims to fix `bessctl` command hanging in some cases.
The original issue is tracked by https://github.com/canonical/sdcore-upf-operator/issues/92.

The usage of `os._exit(n)` is not encouraged as exit handlers are not called and stdio buffer streams are not flushed; however, in this case, nothing is to be performed after this point.