### PR TITLE
feat: migrate to Ubuntu 22.04 and use shared workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 Intel Corporation
+# Copyright 2025 Canonical Ltd.
 
 version: 2
 updates:
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "21:00"
-      timezone: "America/Los_Angeles"
 
   - package-ecosystem: "docker"
     directory: "/env/"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
     with:
       branch_name: ${{ github.ref }}
       dockerfile: env/Dockerfile-cndp
+      ignored_rules: DL3008,DL3013
 
   license-check:
     uses: omec-project/.github/.github/workflows/license-check.yml@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   clang-format:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         path:
@@ -26,73 +25,36 @@ jobs:
             exclude: ''       # Nothing to exclude
           - check: 'sample_plugin/protobuf'
             exclude: ''       # Nothing to exclude
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Clang-format check
-      uses: jidicula/clang-format-action@v4.11.0
-      with:
-        clang-format-version: '12'
-        check-path: ${{ matrix.path['check'] }}
-        exclude-regex: ${{ matrix.path['exclude'] }}
+    uses: dariofaccin/.github/.github/workflows/check-clang-format.yml@add-bess-specific-workflows
+    with:
+      branch_name: ${{ github.ref }}
+      clang_format_version: '12'
+      check_path: ${{ matrix.path['check'] }}
+      exclude_regex: ${{ matrix.path['exclude'] }}
 
   check-spelling:
-    name: Markdown spellcheck
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Check Spelling
-        uses: rojopolis/spellcheck-github-actions@0.36.0
-        with:
-          config_path: .spellcheck.yml
-          task_name: Markdown
+    uses: omec-project/.github/.github/workflows/check-spelling.yml@main
+    with:
+      branch_name: ${{ github.ref }}
 
   hadolint:
-    name: hadolint
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Dockerfile linter
-        uses: hadolint/hadolint-action@v3.1.0
-        # For now, ignoring:
-        # DL3008 warning: Pin versions in apt get install (e.g., apt-get install <package>=<version>)
-        with:
-          dockerfile: env/Dockerfile
-          ignore: DL3008
+    uses: dariofaccin/.github/.github/workflows/hadolint.yml@add-bess-specific-workflows
+    with:
+      branch_name: ${{ github.ref }}
+      dockerfile: env/Dockerfile
 
   hadolint-cndp:
-    name: hadolint
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Dockerfile linter
-        uses: hadolint/hadolint-action@v3.1.0
-        # For now, ignoring:
-        # DL3008 warning: Pin versions in apt get install (e.g., apt-get install <package>=<version>); and
-        # DL3013 warning: Pin versions in pip (e.g., pip install <package>==<version>)
-        with:
-          dockerfile: env/Dockerfile-cndp
-          ignore: DL3008,DL3013
+    uses: dariofaccin/.github/.github/workflows/hadolint.yml@add-bess-specific-workflows
+    with:
+      branch_name: ${{ github.ref }}
+      dockerfile: env/Dockerfile-cndp
 
   license-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    uses: omec-project/.github/.github/workflows/license-check.yml@main
+    with:
+      branch_name: ${{ github.ref }}
 
-      - name: reuse lint
-        uses: fsfe/reuse-action@v3
-
-  fossa-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: FOSSA scan
-        uses: fossa-contrib/fossa-action@v3
-        with:
-          fossa-api-key: 0c3bbcdf20e157bbd487dae173751b28
+  fossa-scan:
+    uses: omec-project/.github/.github/workflows/fossa-scan.yml@main
+    with:
+      branch_name: ${{ github.ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,14 +2,9 @@
 # Copyright 2022-Present Intel Corporation
 # Copyright 2025 Canonical Ltd.
 on:
-  workflow_dispatch:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
-      - TELCO-*
 
 jobs:
   build:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022-Present Intel Corporation
-
-name: Build and Test
+# Copyright 2025 Canonical Ltd.
 on:
   pull_request:
     branches:
@@ -9,34 +8,6 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup environment (Hugepages)
-        run: sudo sysctl -w vm.nr_hugepages=512
-
-      - name: Setup dependencies
-        run: |
-          sudo apt-get install -y ccache libbpf0
-          sudo pip3 install -r requirements.txt
-          yes n | ./env/rebuild_images.py focal64
-          sudo mkdir -p /mnt/huge
-          sudo mount -t hugetlbfs nodev /mnt/huge
-          export CXX="ccache $VER_CXX"
-          ccache -s
-
-      - name: Build BESS
-        run: |
-          sudo ./container_build.py bess
-          sudo ./container_build.py kmod_buildtest
-
-      - name: Test BESS
-        run: |
-          (cd core && ./all_test --gtest_shuffle)
-          coverage run -m unittest discover -v
-          python3 bessctl/run_module_tests.py
-          sudo python3 bessctl/run_module_tests.py --test_dir bessctl/module_tests/cndp
-          ccache -s
-          bessctl/bessctl daemon stop
-          [[ ${COVERAGE:-0} == 0 ]] || { sleep 3; codecov --gcov-exec gcov-7; }
+    uses: dariofaccin/.github/.github/workflows/bess-build-test.yml@add-bess-specific-workflows
+    with:
+      branch_name: ${{ github.ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,9 +2,14 @@
 # Copyright 2022-Present Intel Corporation
 # Copyright 2025 Canonical Ltd.
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
+      - TELCO-*
 
 jobs:
   build:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2024-Present Intel Corporation
-
-name: Build and Push image
+# Copyright 2025 Canonical Ltd.
 on:
   push:
     branches:
@@ -9,16 +8,4 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
-    if: github.repository_owner == 'omec-project'
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/login-action@v3.0.0
-        with:
-          registry: registry.aetherproject.org
-          username: ${{ secrets.AETHER_REGISTRY_USERNAME }}
-          password: ${{ secrets.AETHER_REGISTRY_PASSWORD }}
-
-      - name: Build and push new BESS base image
-        run: yes y | ./env/rebuild_images.py focal64
+    uses: dariofaccin/.github/.github/workflows/bess-release-image.yml@add-bess-specific-workflows

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,24 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 Intel Corporation
-
-name: Stale issues and PRs
-
+# Copyright 2024 Intel Corporation
+# Copyright 2025 Canonical Ltd.
 on:
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v9
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue has been stale for 30 days and will be closed in 5 days. Comment to keep it open.'
-          stale-pr-message: 'This pull request has been stale for 30 days and will be closed in 5 days. Comment to keep it open.'
-          stale-issue-label: 'Stale/issue'
-          stale-pr-label: 'Stale/pr'
-          exempt-issue-labels: 'awaiting-approval,work-in-progress'
-          exempt-pr-labels: 'awaiting-approval,work-in-progress'
-          days-before-stale: 30
-          days-before-close: 5
+    uses: omec-project/.github/.github/workflows/stale-issue.yml@main
+    with:
+      days_before_stale: 30
+      days_before_close: 5
+    secrets: inherit

--- a/bessctl/module_tests/url_filter.py
+++ b/bessctl/module_tests/url_filter.py
@@ -29,7 +29,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import logging
 import socket
 import sys
 from test_utils import *
@@ -100,12 +99,6 @@ class BessUrlFilterTest(BessModuleTestCase):
         self.assertSamePackets(pkt_outs[0][1], good_pkt)
 
         self.assertEquals(len(pkt_outs[1]), 2)
-        packet_1 = pkt_outs[1][0]
-        packet_2 = scapy.Ether(err_pkt)
-        logging.basicConfig()
-        logger = logging.getLogger("UT")
-        logger.warning("Packet 1: %s", packet_1)
-        logger.warning("Packet 2: %s", packet_2)
         self.assertSamePackets(pkt_outs[1][0], err_pkt)
 
     def test_urlfilter_selfconfig(self):

--- a/bessctl/module_tests/url_filter.py
+++ b/bessctl/module_tests/url_filter.py
@@ -29,6 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import socket
 import sys
 from test_utils import *
@@ -99,6 +100,12 @@ class BessUrlFilterTest(BessModuleTestCase):
         self.assertSamePackets(pkt_outs[0][1], good_pkt)
 
         self.assertEquals(len(pkt_outs[1]), 2)
+        packet_1 = pkt_outs[1][0]
+        packet_2 = scapy.Ether(err_pkt)
+        logging.basicConfig()
+        logger = logging.getLogger("UT")
+        logger.warning("Packet 1: %s", packet_1)
+        logger.warning("Packet 2: %s", packet_2)
         self.assertSamePackets(pkt_outs[1][0], err_pkt)
 
     def test_urlfilter_selfconfig(self):

--- a/bin/dpdk-devbind.py
+++ b/bin/dpdk-devbind.py
@@ -1,37 +1,38 @@
 #! /usr/bin/env python3
 #
-#   BSD LICENSE
+# BSD LICENSE
 #
-#   Copyright(c) 2010-2014 Intel Corporation. All rights reserved.
-#   All rights reserved.
+# Copyright(c) 2010-2014 Intel Corporation. All rights reserved.
+# Copyright 2025 Canonical Ltd.
+# All rights reserved.
 #
-#   SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
 #
-#   Redistribution and use in source and binary forms, with or without
-#   modification, are permitted provided that the following conditions
-#   are met:
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
 #
-#     * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in
-#       the documentation and/or other materials provided with the
-#       distribution.
-#     * Neither the name of Intel Corporation nor the names of its
-#       contributors may be used to endorse or promote products derived
-#       from this software without specific prior written permission.
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
 #
-#   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-#   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-#   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-#   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-#   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-#   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-#   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-#   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-#   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-#   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
 import sys

--- a/core/Makefile
+++ b/core/Makefile
@@ -67,13 +67,13 @@ HAS_PKG_CONFIG := $(shell command -v $(PKG_CONFIG) 2>&1 >/dev/null && echo yes |
 
 # We always want these libraries to be dynamically linked even when the
 # user requests a static build.
-ALWAYS_DYN_LIBS := -lpthread -ldl
+ALWAYS_DYN_LIBS := -lpcap -lpthread -ldl -lgrpc++
 # These libraries are not supported by pkg-config.
-ALWAYS_LIBS := -lpcap -lgflags -lnuma
+ALWAYS_LIBS := -lgflags -lnuma
 # If pkg-config is available, we just need a list of the dependecies.
-PKG_CONFIG_DEPS := libdpdk libglog protobuf grpc++ libunwind zlib libcndp
+PKG_CONFIG_DEPS := libdpdk libglog protobuf libcndp
 # If pkg-config is not available, we need to list the libs we depend on.
-NO_PKG_CONFIG_LIBS := -lglog -lgflags -lprotobuf -lgrpc++ -lunwind -lz
+NO_PKG_CONFIG_LIBS := -lglog -lgflags -lprotobuf
 # If pkg-config is not available and we're static linking, we also need
 # the indirect dependecies.  This is annoying, because they may change
 # in future versions.

--- a/core/Makefile
+++ b/core/Makefile
@@ -103,7 +103,6 @@ CXXFLAGS += -std=c++17 -g3 -ggdb3 -march=$(CPU) \
             -isystem $(dir $<).. -isystem $(COREDIR)/modules \
             -D_GNU_SOURCE \
             -Werror -Wall -Wextra -Wcast-align -Wno-error=deprecated-declarations \
-            -Wno-maybe-uninitialized -Wno-nonnull \
             -Wno-error=array-bounds \
             $(PKG_CFLAGS)
 

--- a/core/Makefile
+++ b/core/Makefile
@@ -103,6 +103,7 @@ CXXFLAGS += -std=c++17 -g3 -ggdb3 -march=$(CPU) \
             -isystem $(dir $<).. -isystem $(COREDIR)/modules \
             -D_GNU_SOURCE \
             -Werror -Wall -Wextra -Wcast-align -Wno-error=deprecated-declarations \
+            -Wno-maybe-uninitialized -Wno-nonnull \
             -Wno-error=array-bounds \
             $(PKG_CFLAGS)
 

--- a/core/drivers/cndp.cc
+++ b/core/drivers/cndp.cc
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(c) 2019-2021 Intel Corporation.
- */
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright(c) 2019-2021 Intel Corporation.
+// Copyright 2025 Canonical Ltd.
 
 #include "cndp.h"
 #include <algorithm>        // std::min

--- a/core/drivers/cndp.h
+++ b/core/drivers/cndp.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(c) 2019-2021 Intel Corporation.
- */
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright(c) 2019-2021 Intel Corporation.
+// Copyright 2025 Canonical Ltd.
 
 #ifndef BESS_DRIVERS_CNDP_H_
 #define BESS_DRIVERS_CNDP_H_

--- a/core/kmod/sn_netdev.c
+++ b/core/kmod/sn_netdev.c
@@ -59,6 +59,8 @@
 
 static int sn_poll(struct napi_struct *napi, int budget);
 static void sn_enable_interrupt(struct sn_queue *rx_queue);
+static netdev_features_t sn_fix_features(struct net_device *dev,
+                                         netdev_features_t features);
 
 static void sn_test_cache_alignment(struct sn_device *dev)
 {
@@ -172,8 +174,12 @@ static int sn_alloc_queues(struct sn_device *dev,
 	}
 
 	for (i = 0; i < dev->num_rxq; i++) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,0,0)
 		netif_napi_add(dev->netdev, &dev->rx_queues[i]->rx.napi,
 				sn_poll, NAPI_POLL_WEIGHT);
+#else
+		netif_napi_add(dev->netdev, &dev->rx_queues[i]->rx.napi, sn_poll);
+#endif
 #ifdef CONFIG_NET_RX_BUSY_POLL
 		napi_hash_add(&dev->rx_queues[i]->rx.napi);
 #endif
@@ -274,7 +280,6 @@ static void sn_process_rx_metadata(struct sk_buff *skb,
 		skb->encapsulation = 1;
 #endif
 		/* fall through */
-
 	case SN_RX_CSUM_CORRECT:
 		skb->ip_summed = CHECKSUM_UNNECESSARY;
 		break;
@@ -494,7 +499,7 @@ static int sn_poll(struct napi_struct *napi, int budget)
 		/* last check for race condition.
 		 * see sn_enable_interrupt() */
 		if (rx_queue->dev->ops->pending_rx(rx_queue)) {
-			napi_reschedule(napi);
+			napi_schedule(napi); // Changed from napi_reschedule to napi_schedule
 			sn_disable_interrupt(rx_queue);
 		}
 	}
@@ -554,7 +559,6 @@ skip_send:
 	case NET_XMIT_CN:
 		queue->tx.stats.throttled++;
 		/* fall through */
-
 	case NET_XMIT_SUCCESS:
 		queue->tx.stats.packets++;
 		queue->tx.stats.bytes += skb->len;
@@ -827,7 +831,7 @@ int sn_create_netdev(void *bar, struct sn_device **dev_ret)
 	netdev->netdev_ops = &sn_netdev_ops;
 	netdev->ethtool_ops = &sn_ethtool_ops;
 
-	memcpy(netdev->dev_addr, conf->mac_addr, ETH_ALEN);
+	memcpy(netdev->dev_addr, (void *)conf->mac_addr, ETH_ALEN);
 
 	ret = sn_alloc_queues(dev, conf + 1,
 			conf->bar_size - sizeof(struct sn_conf_space),

--- a/core/kmod/sndrv.c
+++ b/core/kmod/sndrv.c
@@ -1,35 +1,37 @@
-/*-
- *   BSD LICENSE
- *
- *   Copyright(c) 2014 Sangjin Han All rights reserved.
- *
- *   SPDX-License-Identifier: BSD-3-Clause or GPL-2.0-only
- *
- *   Redistribution and use in source and binary forms, with or without
- *   modification, are permitted provided that the following conditions
- *   are met:
- *
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in
- *       the documentation and/or other materials provided with the
- *       distribution.
- *
- *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- */
-/* Dual BSD/GPL */
+// BSD LICENSE
+//
+// Copyright(c) 2014 Sangjin Han All rights reserved.
+// Copyright 2025 Canonical Ltd.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Dual BSD/GPL
 
 #include "sn_common.h"
 #include "sn_kernel.h"

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -164,8 +164,10 @@ class ExactMatch final : public Module {
     }
 
     if (mt_attr_name.length() > 0) {
-      v->attr_id = m->AddMetadataAttr(
+      if (m != nullptr) {
+        v->attr_id = m->AddMetadataAttr(
           mt_attr_name, v->size, bess::metadata::Attribute::AccessMode::kWrite);
+        }
       if (v->attr_id < 0) {
         return std::make_pair(
             -v->attr_id,

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -372,7 +372,7 @@ static uint64_t l2_addr_to_u64(char *addr) {
 
 static void l2_forward_init_test() {
   int ret;
-  struct l2_table l2tbl;
+  struct l2_table l2tbl = {};
 
   ret = l2_init(&l2tbl, 0, 0);
   DCHECK_LT(ret, 0);
@@ -410,7 +410,7 @@ static void l2_forward_init_test() {
 
 static void l2_forward_entry_test() {
   int ret;
-  struct l2_table l2tbl;
+  struct l2_table l2tbl = {};
 
   uint64_t addr1 = 0x0123456701234567;
   uint64_t addr2 = 0x9876543210987654;
@@ -447,7 +447,7 @@ static void l2_forward_entry_test() {
 
 static void l2_forward_flush_test() {
   int ret;
-  struct l2_table l2tbl;
+  struct l2_table l2tbl = {};
 
   uint64_t addr1 = 0x0123456701234567;
   uint16_t index1 = 0x0123;
@@ -476,7 +476,7 @@ static void l2_forward_collision_test() {
 
   int ret;
   int i;
-  struct l2_table l2tbl;
+  struct l2_table l2tbl = {};
 
   uint64_t addr[max_hb_cnt];
   uint16_t idx[max_hb_cnt];

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -135,7 +135,7 @@ inline static bess::Packet *Generate403Packet(const Ethernet::Address &src_eth,
 
   tcp->checksum = bess::utils::CalculateIpv4TcpChecksum(*tcp, src_ip, dst_ip,
                                                         sizeof(*tcp) + len);
-  ip->checksum = bess::utils::CalculateIpv4NoOptChecksum(*ip);
+  ip->checksum = bess::utils::CalculateIpv4Checksum(*ip);
 
   return pkt;
 }

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -290,10 +290,6 @@ static inline uint16_t CalculateIpv4Checksum(const Ipv4 &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
   size_t ip_header_len = iph.header_length << 2;
 
-  if (likely(ip_header_len == sizeof(iph))) {
-    return CalculateIpv4NoOptChecksum(iph);
-  }
-
   if (unlikely(ip_header_len < sizeof(iph))) {
     return 0;  // Invalid IP header. Give up.
   }

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -256,10 +256,6 @@ static inline bool VerifyIpv4Checksum(const Ipv4 &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
   size_t ip_header_len = iph.header_length << 2;
 
-  if (likely(ip_header_len == sizeof(iph))) {
-    return VerifyIpv4NoOptChecksum(iph);
-  }
-
   if (unlikely(ip_header_len < sizeof(iph))) {
     return false;  // Invalid IP header
   }

--- a/core/utils/exact_match_table.h
+++ b/core/utils/exact_match_table.h
@@ -426,8 +426,10 @@ class ExactMatchTable {
     }
 
     if (mt_attr_name.length() > 0) {
-      f->attr_id = m->AddMetadataAttr(mt_attr_name, f->size,
-                                      metadata::Attribute::AccessMode::kRead);
+      if (m != nullptr) {
+        f->attr_id = m->AddMetadataAttr(mt_attr_name, f->size,
+                                        metadata::Attribute::AccessMode::kRead);
+      }
       if (f->attr_id < 0) {
         return MakeError(-f->attr_id,
                          Format("idx %d: add_metadata_attr() failed", idx));

--- a/core/utils/exact_match_table_test.cc
+++ b/core/utils/exact_match_table_test.cc
@@ -70,85 +70,6 @@ TEST(EmTableTest, AddRule) {
   em.DeInit();
 }
 
-TEST(EmTableTest, LookupOneFieldOneRule) {
-  ExactMatchTable<uint16_t> em;
-  em.AddField(0, 4, 0, 0);
-  ExactMatchRuleFields rule = {
-      {0x04, 0x03, 0x02, 0x01},
-  };
-  uint64_t buf = 0x01020304;
-  uint64_t bad_buf = 0xBAD;
-  ExactMatchKey key = em.MakeKey(&buf);
-  ExactMatchKey bad_key = em.MakeKey(&bad_buf);
-  em.Init(1 << 10);
-  em.AddRule(0xBEEF, rule);
-  EXPECT_EQ(0xBEEF, em.Find(key, 0xDEAD));
-  EXPECT_EQ(0xDEAD, em.Find(bad_key, 0xDEAD));
-  em.ClearRules();
-  em.DeInit();
-}
-
-// TEST(EmTableTest, LookupTwoFieldsOneRule) {
-//   ExactMatchTable<uint16_t> em;
-//   ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
-//   ASSERT_EQ(0, em.AddField(6, 2, 0, 1).first);
-//   ASSERT_EQ(2, em.num_fields());
-//   ExactMatchRuleFields rule = {{0x04, 0x03, 0x02, 0x01}, {0x06, 0x05}};
-//   uint64_t buf = 0x0506000001020304;
-//   ExactMatchKey key = em.MakeKey(&buf);
-//   em.Init(1 << 10);
-//   ASSERT_EQ(0, em.AddRule(0xBEEF, rule).first);
-//   uint16_t ret = em.Find(key, 0xDEAD);
-//   ASSERT_EQ(0xBEEF, ret);
-//   em.ClearRules();
-//   em.DeInit();
-// }
-
-TEST(EmTableTest, LookupTwoFieldsTwoRules) {
-  ExactMatchTable<uint16_t> em;
-  ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
-  ASSERT_EQ(0, em.AddField(6, 2, 0, 1).first);
-  ASSERT_EQ(2, em.num_fields());
-  em.Init(1 << 10);
-  ExactMatchRuleFields rule1 = {{0x04, 0x03, 0x02, 0x01}, {0x06, 0x05}};
-  ExactMatchRuleFields rule2 = {{0x0F, 0x0E, 0x0D, 0x0C}, {0x06, 0x05}};
-  uint64_t buf1 = 0x0506000001020304;
-  uint64_t buf2 = 0x050600000C0D0E0F;
-  uint64_t bad_buf = 0xBAD;
-  const void *bufs[3] = {&buf1, &buf2, &bad_buf};
-  ExactMatchKey keys[3];
-  em.MakeKeys(bufs, keys, 3);
-  ASSERT_EQ(0, em.AddRule(0xF00, rule1).first);
-  ASSERT_EQ(0, em.AddRule(0xBA2, rule2).first);
-  EXPECT_EQ(0xF00, em.Find(keys[0], 0xDEAD));
-  EXPECT_EQ(0xBA2, em.Find(keys[1], 0xDEAD));
-  EXPECT_EQ(0xDEAD, em.Find(keys[2], 0xDEAD));
-  em.ClearRules();
-  em.DeInit();
-}
-
-// This test is for a specific bug introduced at one point
-// where the MakeKeys function didn't clear out any random
-// crud that might be on the stack.
-// TEST(EmTableTest, IgnoreBytesPastEnd) {
-//   ExactMatchTable<uint16_t> em;
-//   ASSERT_EQ(0, em.AddField(6, 1, 0, 0).first);
-//   ASSERT_EQ(0, em.AddField(7, 8, 0, 1).first);
-//   em.Init(1 << 10);
-//   uint64_t buf[2] = {0x0102030405060708, 0x1112131415161718};
-//   const void *bufs[1] = {&buf};
-//   ExactMatchRuleFields rule = {
-//       {0x02}, {0x01, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12}};
-//   ExactMatchKey keys[1];
-//   memset(keys, 0x55, sizeof(keys));
-//   em.MakeKeys(bufs, keys, 1);
-//   ASSERT_EQ(0, em.AddRule(0x600d, rule).first);
-//   uint16_t ret = em.Find(keys[0], 0xDEAD);
-//   ASSERT_EQ(0x600d, ret);
-//   em.ClearRules();
-//   em.DeInit();
-// }
-
 TEST(EmTableTest, FindMakeKeysPktBatch) {
   const size_t n = 2;
   ExactMatchTable<uint16_t> em;
@@ -179,6 +100,85 @@ TEST(EmTableTest, FindMakeKeysPktBatch) {
     // Packets are bogus, shouldn't match anything.
     ASSERT_EQ(0xDEAD, em.Find(keys[i], 0xDEAD));
   }
+  em.ClearRules();
+  em.DeInit();
+}
+
+TEST(EmTableTest, LookupOneFieldOneRule) {
+  ExactMatchTable<uint16_t> em;
+  em.AddField(0, 4, 0, 0);
+  ExactMatchRuleFields rule = {
+      {0x04, 0x03, 0x02, 0x01},
+  };
+  uint64_t buf = 0x01020304;
+  uint64_t bad_buf = 0xBAD;
+  ExactMatchKey key = em.MakeKey(&buf);
+  ExactMatchKey bad_key = em.MakeKey(&bad_buf);
+  em.Init(1 << 10);
+  em.AddRule(0xBEEF, rule);
+  EXPECT_EQ(0xBEEF, em.Find(key, 0xDEAD));
+  EXPECT_EQ(0xDEAD, em.Find(bad_key, 0xDEAD));
+  em.ClearRules();
+  em.DeInit();
+}
+
+TEST(EmTableTest, LookupTwoFieldsOneRule) {
+  ExactMatchTable<uint16_t> em;
+  ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
+  ASSERT_EQ(0, em.AddField(6, 2, 0, 1).first);
+  ASSERT_EQ(2, em.num_fields());
+  ExactMatchRuleFields rule = {{0x04, 0x03, 0x02, 0x01}, {0x06, 0x05}};
+  uint64_t buf = 0x0506000001020304;
+  ExactMatchKey key = em.MakeKey(&buf);
+  em.Init(1 << 10);
+  ASSERT_EQ(0, em.AddRule(0xBEEF, rule).first);
+  uint16_t ret = em.Find(key, 0xDEAD);
+  ASSERT_EQ(0xBEEF, ret);
+  em.ClearRules();
+  em.DeInit();
+}
+
+TEST(EmTableTest, LookupTwoFieldsTwoRules) {
+  ExactMatchTable<uint16_t> em;
+  ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
+  ASSERT_EQ(0, em.AddField(6, 2, 0, 1).first);
+  ASSERT_EQ(2, em.num_fields());
+  em.Init(1 << 10);
+  ExactMatchRuleFields rule1 = {{0x04, 0x03, 0x02, 0x01}, {0x06, 0x05}};
+  ExactMatchRuleFields rule2 = {{0x0F, 0x0E, 0x0D, 0x0C}, {0x06, 0x05}};
+  uint64_t buf1 = 0x0506000001020304;
+  uint64_t buf2 = 0x050600000C0D0E0F;
+  uint64_t bad_buf = 0xBAD;
+  const void *bufs[3] = {&buf1, &buf2, &bad_buf};
+  ExactMatchKey keys[3];
+  em.MakeKeys(bufs, keys, 3);
+  ASSERT_EQ(0, em.AddRule(0xF00, rule1).first);
+  ASSERT_EQ(0, em.AddRule(0xBA2, rule2).first);
+  EXPECT_EQ(0xF00, em.Find(keys[0], 0xDEAD));
+  EXPECT_EQ(0xBA2, em.Find(keys[1], 0xDEAD));
+  EXPECT_EQ(0xDEAD, em.Find(keys[2], 0xDEAD));
+  em.ClearRules();
+  em.DeInit();
+}
+
+// This test is for a specific bug introduced at one point
+// where the MakeKeys function didn't clear out any random
+// crud that might be on the stack.
+TEST(EmTableTest, IgnoreBytesPastEnd) {
+  ExactMatchTable<uint16_t> em;
+  ASSERT_EQ(0, em.AddField(6, 1, 0, 0).first);
+  ASSERT_EQ(0, em.AddField(7, 8, 0, 1).first);
+  em.Init(1 << 10);
+  uint64_t buf[2] = {0x0102030405060708, 0x1112131415161718};
+  const void *bufs[1] = {&buf};
+  ExactMatchRuleFields rule = {
+      {0x02}, {0x01, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12}};
+  ExactMatchKey keys[1];
+  memset(keys, 0x55, sizeof(keys));
+  em.MakeKeys(bufs, keys, 1);
+  ASSERT_EQ(0, em.AddRule(0x600d, rule).first);
+  uint16_t ret = em.Find(keys[0], 0xDEAD);
+  ASSERT_EQ(0x600d, ret);
   em.ClearRules();
   em.DeInit();
 }

--- a/core/utils/exact_match_table_test.cc
+++ b/core/utils/exact_match_table_test.cc
@@ -88,21 +88,21 @@ TEST(EmTableTest, LookupOneFieldOneRule) {
   em.DeInit();
 }
 
-TEST(EmTableTest, LookupTwoFieldsOneRule) {
-  ExactMatchTable<uint16_t> em;
-  ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
-  ASSERT_EQ(0, em.AddField(6, 2, 0, 1).first);
-  ASSERT_EQ(2, em.num_fields());
-  ExactMatchRuleFields rule = {{0x04, 0x03, 0x02, 0x01}, {0x06, 0x05}};
-  uint64_t buf = 0x0506000001020304;
-  ExactMatchKey key = em.MakeKey(&buf);
-  em.Init(1 << 10);
-  ASSERT_EQ(0, em.AddRule(0xBEEF, rule).first);
-  uint16_t ret = em.Find(key, 0xDEAD);
-  ASSERT_EQ(0xBEEF, ret);
-  em.ClearRules();
-  em.DeInit();
-}
+// TEST(EmTableTest, LookupTwoFieldsOneRule) {
+//   ExactMatchTable<uint16_t> em;
+//   ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
+//   ASSERT_EQ(0, em.AddField(6, 2, 0, 1).first);
+//   ASSERT_EQ(2, em.num_fields());
+//   ExactMatchRuleFields rule = {{0x04, 0x03, 0x02, 0x01}, {0x06, 0x05}};
+//   uint64_t buf = 0x0506000001020304;
+//   ExactMatchKey key = em.MakeKey(&buf);
+//   em.Init(1 << 10);
+//   ASSERT_EQ(0, em.AddRule(0xBEEF, rule).first);
+//   uint16_t ret = em.Find(key, 0xDEAD);
+//   ASSERT_EQ(0xBEEF, ret);
+//   em.ClearRules();
+//   em.DeInit();
+// }
 
 TEST(EmTableTest, LookupTwoFieldsTwoRules) {
   ExactMatchTable<uint16_t> em;
@@ -130,24 +130,24 @@ TEST(EmTableTest, LookupTwoFieldsTwoRules) {
 // This test is for a specific bug introduced at one point
 // where the MakeKeys function didn't clear out any random
 // crud that might be on the stack.
-TEST(EmTableTest, IgnoreBytesPastEnd) {
-  ExactMatchTable<uint16_t> em;
-  ASSERT_EQ(0, em.AddField(6, 1, 0, 0).first);
-  ASSERT_EQ(0, em.AddField(7, 8, 0, 1).first);
-  em.Init(1 << 10);
-  uint64_t buf[2] = {0x0102030405060708, 0x1112131415161718};
-  const void *bufs[1] = {&buf};
-  ExactMatchRuleFields rule = {
-      {0x02}, {0x01, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12}};
-  ExactMatchKey keys[1];
-  memset(keys, 0x55, sizeof(keys));
-  em.MakeKeys(bufs, keys, 1);
-  ASSERT_EQ(0, em.AddRule(0x600d, rule).first);
-  uint16_t ret = em.Find(keys[0], 0xDEAD);
-  ASSERT_EQ(0x600d, ret);
-  em.ClearRules();
-  em.DeInit();
-}
+// TEST(EmTableTest, IgnoreBytesPastEnd) {
+//   ExactMatchTable<uint16_t> em;
+//   ASSERT_EQ(0, em.AddField(6, 1, 0, 0).first);
+//   ASSERT_EQ(0, em.AddField(7, 8, 0, 1).first);
+//   em.Init(1 << 10);
+//   uint64_t buf[2] = {0x0102030405060708, 0x1112131415161718};
+//   const void *bufs[1] = {&buf};
+//   ExactMatchRuleFields rule = {
+//       {0x02}, {0x01, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12}};
+//   ExactMatchKey keys[1];
+//   memset(keys, 0x55, sizeof(keys));
+//   em.MakeKeys(bufs, keys, 1);
+//   ASSERT_EQ(0, em.AddRule(0x600d, rule).first);
+//   uint16_t ret = em.Find(keys[0], 0xDEAD);
+//   ASSERT_EQ(0x600d, ret);
+//   em.ClearRules();
+//   em.DeInit();
+// }
 
 TEST(EmTableTest, FindMakeKeysPktBatch) {
   const size_t n = 2;

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -4,7 +4,7 @@
 # vim: syntax=dockerfile
 
 # Install CNDP dependencies and build CNDP.
-FROM ubuntu:20.04 AS cndp-build
+FROM ubuntu:22.04 AS cndp-build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
@@ -59,7 +59,7 @@ RUN make static_build=1 rebuild install
 WORKDIR /cndp/lang/go/stats/prometheus
 RUN go build prometheus.go
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Install CNDP dependencies
 ENV DEBIAN_FRONTEND=noninteractive

--- a/env/Dockerfile-cndp
+++ b/env/Dockerfile-cndp
@@ -8,7 +8,7 @@
 # --build-arg https_proxy=$http_proxy --build-arg no_proxy="$no_proxy" \
 # -t besscndp -f env/Dockerfile-cndp .
 
-FROM ubuntu:20.04 AS cndp-build
+FROM ubuntu:22.04 AS cndp-build
 
 # Install CNDP dependencies and build CNDP.
 ENV DEBIAN_FRONTEND=noninteractive
@@ -64,7 +64,7 @@ RUN make static_build=1 rebuild install
 WORKDIR /cndp/lang/go/stats/prometheus
 RUN go build prometheus.go
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Install CNDP dependencies
 ENV DEBIAN_FRONTEND=noninteractive

--- a/env/rebuild_images.py
+++ b/env/rebuild_images.py
@@ -47,6 +47,7 @@ FULL_TARGET = TARGET_REGISTRY + TARGET_REPOSITORY + TARGET
 
 imgs = {
     'focal64': {'base': 'ubuntu:focal', 'tag_suffix': ''},
+    'jammy64': {'base': 'ubuntu:jammy', 'tag_suffix': ''},
 }
 
 
@@ -64,7 +65,7 @@ def run_cmd(cmd, shell=False):
 def build(env):
     base = imgs[env]['base']
     tag_suffix = imgs[env]['tag_suffix']
-    bess_dpdk_branch = os.getenv('BESS_DPDK_BRANCH', 'master')
+    bess_dpdk_branch = os.getenv('BESS_DPDK_BRANCH', 'main')
     version = time.strftime('%y%m%d')
 
     run_cmd('docker build -f env/Dockerfile '

--- a/env/rebuild_images.py
+++ b/env/rebuild_images.py
@@ -40,7 +40,10 @@ import subprocess
 import sys
 import time
 
-TARGET_REPO = 'registry.aetherproject.org/sdcore/bess_build'
+TARGET_REGISTRY = os.getenv("DOCKER_REGISTRY", "registry.aetherproject.org/")
+TARGET_REPOSITORY = os.getenv("DOCKER_REPOSITORY", "sdcore/")
+TARGET = "bess_build"
+FULL_TARGET = TARGET_REGISTRY + TARGET_REPOSITORY + TARGET
 
 imgs = {
     'focal64': {'base': 'ubuntu:focal', 'tag_suffix': ''},
@@ -68,19 +71,19 @@ def build(env):
             '--build-arg BASE_IMAGE={base} '
             '--build-arg BESS_DPDK_BRANCH={branch} '
             '-t {target}:latest{suffix} -t {target}:{version}{suffix} '
-            '.'.format(base=base, branch=bess_dpdk_branch, target=TARGET_REPO,
+            '.'.format(base=base, branch=bess_dpdk_branch, target=FULL_TARGET,
                        version=version, suffix=tag_suffix))
 
-    print('Build succeeded: {}:{}{}'.format(TARGET_REPO, version, tag_suffix))
-    print('Build succeeded: {}:latest{}'.format(TARGET_REPO, tag_suffix))
+    print('Build succeeded: {}:{}{}'.format(FULL_TARGET, version, tag_suffix))
+    print('Build succeeded: {}:latest{}'.format(FULL_TARGET, tag_suffix))
 
     return version, tag_suffix
 
 
 def push(version, tag_suffix):
     run_cmd('docker login')
-    run_cmd('docker push {}:latest{}'.format(TARGET_REPO, tag_suffix))
-    run_cmd('docker push {}:{}{}'.format(TARGET_REPO, version, tag_suffix))
+    run_cmd('docker push {}:latest{}'.format(FULL_TARGET, tag_suffix))
+    run_cmd('docker push {}:{}{}'.format(FULL_TARGET, version, tag_suffix))
 
 
 def main(argv):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@
 
 coverage
 grpcio
+protobuf==3.20.3
 pyroute2
 scapy


### PR DESCRIPTION
This PR migrates the bess build steps from `ubuntu-20.04` to `ubuntu-22.04` and uses the common GitHub workflows from the `.github` folder in omec-project.

Changes:
- variables are initialized to avoid unitialized and null warnings
- checksum util: avoid fallback to `CalculateIpv4NoOptChecksum`
- UrlFilter module: calculate IPv4 checksum using `CalculateIpv4Checksum` instead of `CalculateIpv4NoOptChecksum`
- ExactMatch module tests: do not shuffle to prevent random failures (may need further investigation)