### PR TITLE
ci: add whitespace checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ permissions:
   contents: read
 
 jobs:
+  whitespace:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+
   clang-format:
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Temporary/hidden files
 .*
+!.pre-commit-config.yaml
 *.dump
 cscope.*
 *.vim

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Intel Corporation
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,5 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+        # Packet fixtures intentionally preserve protocol-specific line endings.
+        exclude: ^core/testdata/test-pktcaptures/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer


### PR DESCRIPTION
## Summary
- add pre-commit hooks for trailing whitespace and end-of-file normalization
- run the hooks in GitHub Actions CI
- preserve protocol-specific packet-capture fixture endings

## Validation
- YAML parsing
- git diff --check